### PR TITLE
Use --webpack-use-polling to switch to fs polling mode on watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ $ serverless invoke local --function <function-name> --path event.json --watch
 Everytime the sources are changed, the function will be executed again with the
 changed sources. The command will watch until the process is terminated.
 
+If you have your sources located on a file system that does not offer events,
+you can enable polling with the `--webpack-use-polling=<time in ms>` option.
+If you omit the value, it defaults to 3000 ms.
+
 All options that are supported by invoke local can be used as usual:
 
 - `--function` or `-f` (required) is the name of the function to run
@@ -299,6 +303,11 @@ Run `serverless offline` or `serverless offline start` to start the Lambda/API s
 In comparison to `serverless offline`, the `start` command will fire an `init` and a `end` lifecycle hook which is needed for `serverless-offline` and e.g. `serverless-dynamodb-local` to switch off resources (see below).
 
 You can find an example setup in the [`examples`][link-examples] folder.
+
+If you have your sources located on a file system that does not offer events,
+e.g. a mounted volume in a Docker container, you can enable polling with the
+`--webpack-use-polling=<time in ms>` option. If you omit the value, it defaults
+to 3000 ms.
 
 #### Custom paths
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
 
@@ -9,8 +10,14 @@ module.exports = {
     this.serverless.cli.log(`Watch function ${functionName}...`);
 
     const compiler = webpack(this.webpackConfig);
+    const watchOptions = {};
+    const usePolling = this.options['webpack-use-polling'];
+    if (usePolling) {
+      watchOptions.poll = _.isInteger(usePolling) ? usePolling : 3000;
+      this.serverless.cli.log(`Enabled polling (${watchOptions.poll} ms)`);
+    }
 
-    compiler.watch({}, (err /*, stats */) => {
+    compiler.watch(watchOptions, (err /*, stats */) => {
       if (err) {
         throw err;
       }

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
 
@@ -7,8 +8,15 @@ module.exports = {
   wpwatch() {
     this.serverless.cli.log('Watching with Webpack...');
 
+    const watchOptions = {};
+    const usePolling = this.options['webpack-use-polling'];
+    if (usePolling) {
+      watchOptions.poll = _.isInteger(usePolling) ? usePolling : 3000;
+      this.serverless.cli.log(`Enabled polling (${watchOptions.poll} ms)`);
+    }
+
     const compiler = webpack(this.webpackConfig);
-    compiler.watch({}, (err, stats) => {
+    compiler.watch(watchOptions, (err, stats) => {
       if (err) {
         throw err;
       }

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -108,5 +108,25 @@ describe('run', () => {
       expect(chdirStub).to.have.been.calledOnce;
       expect(chdirStub).to.have.been.calledWithExactly('originalPath');
     });
+
+    it('should turn on polling and set the default poll interval', () => {
+      module.isWatching = false;
+      const watch = module.watch.bind(module);
+      webpackMock.compilerMock.watch = sandbox.stub().yields(null, {});
+      module.options['webpack-use-polling'] = true;
+
+      watch();
+      expect(webpackMock.compilerMock.watch).to.have.been.calledWith({ poll: 3000 });
+    });
+
+    it('should turn on polling and set the specified poll interval', () => {
+      module.isWatching = false;
+      const watch = module.watch.bind(module);
+      webpackMock.compilerMock.watch = sandbox.stub().yields(null, {});
+      const interval = module.options['webpack-use-polling'] = _.now() % 10000;
+
+      watch();
+      expect(webpackMock.compilerMock.watch).to.have.been.calledWith({ poll: interval });
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #215 

## How did you implement it:

The watch command now evaluates the `--webpack-use-polling` option with and without parameter
and turns on poll mode in Webpack's watch API.
Added documentation in the README to `invoke local --watch` and `serverless-offline`.

## How can we verify it:

Use the switch (`serverless invoke local --watch --webpack-use-polling`) on a file system that does
not support events (Docker mounted volume).

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
