### PR TITLE
Added forceInclude setting to add dynamically required modules explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,24 @@ custom:
 ```
 > Note that only relative path is supported at the moment.
 
+
+Sometimes it might happen that you use dynamic requires in your code, i.e. you
+require modules that are only known at runtime. Webpack is not able to detect
+such externals and the compiled package will miss the needed dependencies.
+In such cases you can force the plugin to include certain modules by setting
+them in the `forceInclude` array property. However the module must appear in
+your service's production dependencies in `package.json`.
+
+```yaml
+# serverless.yml
+custom:
+  webpackIncludeModules:
+    forceInclude:
+      - module1
+      - module2
+```
+
+
 You can find an example setups in the [`examples`][link-examples] folder.
 
 #### Service level packaging

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -110,6 +110,7 @@ module.exports = {
       return BbPromise.resolve(stats);
     }
 
+    const packageForceIncludes = _.get(includes, 'forceInclude', []);
     const packagePath = includes.packagePath || './package.json';
     const packageJsonPath = path.join(process.cwd(), packagePath);
 
@@ -158,7 +159,10 @@ module.exports = {
 
       // (1) Generate dependency composition
       const compositeModules = _.uniq(_.flatMap(stats.stats, compileStats => {
-        const externalModules = getExternalModules.call(this, compileStats);
+        const externalModules = _.concat(
+          getExternalModules.call(this, compileStats),
+          _.map(packageForceIncludes, whitelistedPackage => ({ external: whitelistedPackage }))
+        );
         return getProdModules.call(this, externalModules, packagePath, dependencyGraph);
       }));
 
@@ -196,7 +200,11 @@ module.exports = {
         const modulePackage = {
           dependencies: {}
         };
-        const prodModules = getProdModules.call(this, getExternalModules.call(this, compileStats), packagePath, dependencyGraph);
+        const prodModules = getProdModules.call(this,
+          _.concat(
+            getExternalModules.call(this, compileStats),
+            _.map(packageForceIncludes, whitelistedPackage => ({ external: whitelistedPackage }))
+          ), packagePath, dependencyGraph);
         _.forEach(prodModules, prodModule => {
           const splitModule = _.split(prodModule, '@');
           // If we have a scoped module we have to re-add the @

--- a/tests/mocks/package.mock.json
+++ b/tests/mocks/package.mock.json
@@ -8,7 +8,8 @@
     "npm-programmatic": "0.0.5",
     "uuid": "^5.4.1",
     "ts-node": "^3.2.0",
-    "@scoped/vendor": "1.0.0"
+    "@scoped/vendor": "1.0.0",
+    "pg": "^4.3.5"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
## What did you implement:

Closes #217 
Relates to #223 

## How did you implement it:

The webpack configuration in `serverless.yml` now supports forced include of production node modules that are not detected by Webpack (node-externals) as external dependencies. Samples are dynamically required dependencies that webpack cannot detect.

Forced includes can now be configured as follows:
```yaml
# serverless.yml

custom:
  webpackIncludeModules:
    forceInclude:
      - module1
      - module2
```

This will forcefully package `module1` and `module2` to the service or every function if the modules are specified in the production dependencies in `package.json`.

## How can we verify it:

Use a project that does not reference a production module in its code (so that a `serverless package` will omit the dependency). The package should not contain the module.
Then add the module to the `forceInclude` array. The next `serverless package` should package the included module unconditionally.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
