### PR TITLE
Add and include peer dependencies

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -33,6 +33,24 @@ function getProdModules(externalModules, packagePath, dependencyGraph) {
       }
       prodModules.push(moduleVersion ? `${module.external}@${moduleVersion}` : module.external);
     }
+
+    // Check if the module has any peer dependencies and include them too
+    try {
+      const modulePackagePath = path.join(
+        path.dirname(path.join(process.cwd(), packagePath)),
+        'node_modules',
+        module.external,
+        'package.json'
+      );
+      const peerDependencies = require(modulePackagePath).peerDependencies;
+      if (!_.isEmpty(peerDependencies)) {
+        this.options.verbose && this.serverless.cli.log(`Adding explicit peers for dependency ${module.external}`);
+        const peerModules = getProdModules.call(this, _.map(peerDependencies, (value, key) => ({ external: key })), packagePath, dependencyGraph);
+        Array.prototype.push.apply(prodModules, peerModules);
+      }
+    } catch (e) {
+      this.serverless.cli.log(`WARNING: Could not check for peer dependencies of ${module.external}`);
+    }
   });
 
   return prodModules;

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -24,6 +24,24 @@ function getProdModules(externalModules, packagePath, dependencyGraph) {
 
     if (moduleVersion) {
       prodModules.push(`${module.external}@${moduleVersion}`);
+
+      // Check if the module has any peer dependencies and include them too
+      try {
+        const modulePackagePath = path.join(
+          path.dirname(path.join(process.cwd(), packagePath)),
+          'node_modules',
+          module.external,
+          'package.json'
+        );
+        const peerDependencies = require(modulePackagePath).peerDependencies;
+        if (!_.isEmpty(peerDependencies)) {
+          this.options.verbose && this.serverless.cli.log(`Adding explicit peers for dependency ${module.external}`);
+          const peerModules = getProdModules.call(this, _.map(peerDependencies, (value, key) => ({ external: key })), packagePath, dependencyGraph);
+          Array.prototype.push.apply(prodModules, peerModules);
+        }
+      } catch (e) {
+        this.serverless.cli.log(`WARNING: Could not check for peer dependencies of ${module.external}`);
+      }
     } else if (!_.has(packageJson, `devDependencies.${module.external}`)) {
       // Add transient dependencies if they appear not in the service's dev dependencies
       const originInfo = _.get(dependencyGraph, `dependencies.${module.origin}`, {});
@@ -32,24 +50,6 @@ function getProdModules(externalModules, packagePath, dependencyGraph) {
         this.serverless.cli.log(`WARNING: Could not determine version of module ${module.external}`);
       }
       prodModules.push(moduleVersion ? `${module.external}@${moduleVersion}` : module.external);
-    }
-
-    // Check if the module has any peer dependencies and include them too
-    try {
-      const modulePackagePath = path.join(
-        path.dirname(path.join(process.cwd(), packagePath)),
-        'node_modules',
-        module.external,
-        'package.json'
-      );
-      const peerDependencies = require(modulePackagePath).peerDependencies;
-      if (!_.isEmpty(peerDependencies)) {
-        this.options.verbose && this.serverless.cli.log(`Adding explicit peers for dependency ${module.external}`);
-        const peerModules = getProdModules.call(this, _.map(peerDependencies, (value, key) => ({ external: key })), packagePath, dependencyGraph);
-        Array.prototype.push.apply(prodModules, peerModules);
-      }
-    } catch (e) {
-      this.serverless.cli.log(`WARNING: Could not check for peer dependencies of ${module.external}`);
     }
   });
 

--- a/tests/data/npm-ls-peerdeps.json
+++ b/tests/data/npm-ls-peerdeps.json
@@ -1,0 +1,155 @@
+{
+  "name": "serverless-webpack-babel-example",
+  "version": "1.0.0",
+  "dependencies": {
+    "bluebird": {
+      "version": "3.5.0",
+      "from": "bluebird",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+    },
+    "request": {
+      "version": "2.82.0",
+      "from": "request@^2.34",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
+      "dependencies": {
+        "aws-sign2": {
+          "version": "0.7.0",
+          "from": "aws-sign2@~0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "from": "aws4@^1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "from": "caseless@~0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@^1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "extend": {
+          "version": "3.0.1",
+          "from": "extend@3",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@~0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "from": "form-data@^2.1.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz"
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "from": "har-validator@~5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz"
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "from": "hawk@~6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz"
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "from": "http-signature@~1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@~1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@~0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "from": "mime-types@^2.1.12",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@~0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "from": "performance-now@^2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
+        },
+        "qs": {
+          "version": "6.5.1",
+          "from": "qs@^6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "from": "uuid@^3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "from": "safe-buffer@~5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@~0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@>=2.3.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "from": "tunnel-agent@^0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.1",
+      "from": "request-promise",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.1.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.0",
+          "from": "bluebird",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "from": "request-promise-core@1.1.1",
+          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz"
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "from": "stealthy-require@^1.1.0",
+          "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@>=2.3.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+        }
+      }
+    }
+  }
+}

--- a/tests/data/package-peerdeps.json
+++ b/tests/data/package-peerdeps.json
@@ -1,0 +1,26 @@
+{
+  "name": "serverless-webpack-babel-example",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Babel",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Nicola Peduzzi <thenikso@gmail.com> (http://nikso.net)",
+  "license": "MIT",
+  "devDependencies": {
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.1.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "serverless": "^1.22.0",
+    "serverless-webpack": "^3.0.0",
+    "webpack": "^3.3.0",
+    "webpack-node-externals": "^1.6.0"
+  },
+  "dependencies": {
+    "bluebird": "^3.5.0",
+    "request": "^2.82.0",
+    "request-promise": "^4.2.1"
+  }
+}

--- a/tests/data/rp-package.json
+++ b/tests/data/rp-package.json
@@ -1,0 +1,88 @@
+{
+  "_from": "request-promise",
+  "_id": "request-promise@4.2.1",
+  "_inBundle": false,
+  "_integrity": "sha1-fuxWyJMXqCLL/qmbA5zlQ8LhX2c=",
+  "_location": "/request-promise",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "request-promise",
+    "name": "request-promise",
+    "escapedName": "request-promise",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.1.tgz",
+  "_shasum": "7eec56c89317a822cbfea99b039ce543c2e15f67",
+  "_spec": "request-promise",
+  "_where": "C:\\Projects\\serverless\\test\\babel-dynamically-entries",
+  "author": {
+    "name": "Nicolai Kamenzky",
+    "url": "https://github.com/analog-nico"
+  },
+  "bugs": {
+    "url": "https://github.com/request/request-promise/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "bluebird": "^3.5.0",
+    "request-promise-core": "1.1.1",
+    "stealthy-require": "^1.1.0",
+    "tough-cookie": ">=2.3.0"
+  },
+  "deprecated": false,
+  "description": "The simplified HTTP request client 'request' with Promise support. Powered by Bluebird.",
+  "devDependencies": {
+    "body-parser": "~1.15.2",
+    "chai": "~3.5.0",
+    "chalk": "~1.1.3",
+    "gulp": "~3.9.1",
+    "gulp-coveralls": "~0.1.4",
+    "gulp-eslint": "~2.1.0",
+    "gulp-istanbul": "~1.0.0",
+    "gulp-mocha": "~2.2.0",
+    "lodash": "~4.13.1",
+    "publish-please": "~2.1.4",
+    "request": "^2.34.0",
+    "rimraf": "~2.5.3",
+    "run-sequence": "~1.2.2"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "homepage": "https://github.com/request/request-promise#readme",
+  "keywords": [
+    "xhr",
+    "http",
+    "https",
+    "promise",
+    "request",
+    "then",
+    "thenable",
+    "bluebird"
+  ],
+  "license": "ISC",
+  "main": "./lib/rp.js",
+  "name": "request-promise",
+  "peerDependencies": {
+    "request": "^2.34"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/request/request-promise.git"
+  },
+  "scripts": {
+    "prepublish": "publish-please guard",
+    "publish-please": "publish-please",
+    "test": "gulp ci",
+    "test-publish": "gulp ci-no-cov"
+  },
+  "version": "4.2.1"
+}

--- a/tests/data/stats-peerdeps.js
+++ b/tests/data/stats-peerdeps.js
@@ -1,0 +1,37 @@
+const _ = require('lodash');
+
+module.exports = {
+  stats: [
+    {
+      compilation: {
+        chunks: [
+          {
+            modules: [
+              {
+                identifier: _.constant('"crypto"')
+              },
+              {
+                identifier: _.constant('"uuid/v4"')
+              },
+              {
+                identifier: _.constant('"mockery"')
+              },
+              {
+                identifier: _.constant('"@scoped/vendor/module1"')
+              },
+              {
+                identifier: _.constant('external "bluebird"')
+              },
+              {
+                identifier: _.constant('external "request-promise"')
+              }
+            ]
+          }
+        ],
+        compiler: {
+          outputPath: '/my/Service/Path/.webpack/service'
+        }
+      }
+    }
+  ]
+};


### PR DESCRIPTION
## What did you implement:

Relates to #230 
Closes #223 

## How did you implement it:

When adding external dependencies, their peer dependencies are now included too. This will add dependencies that are missed by Webpack if only the dependency requires its peer, but not the project's code.

Each dependency is checked for peers.

## How can we verify it:

Use a project that depends on `request-promise` but does not use `request` internally. The project
must depend on `request` too, because it is a peer dependency of `request-promise`.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
