### PR TITLE
Log errors in webpack config explicitly.

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -99,7 +99,12 @@ module.exports = {
         throw new this.serverless.classes
           .Error('The webpack plugin could not find the configuration file at: ' + webpackConfigFilePath);
       }
-      this.webpackConfig = require(webpackConfigFilePath);
+      try {
+        this.webpackConfig = require(webpackConfigFilePath);
+      } catch (err) {
+        this.serverless.cli.log(`Could not load webpack config '${webpackConfigFilePath}'`);
+        return BbPromise.reject(err);
+      }
     }
 
     // Default context

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -223,6 +223,16 @@ describe('validate', () => {
           return null;
         });
     });
+
+    it('should fail when importing a broken configuration file', () => {
+      const testConfig = 'invalid.webpack.config.js';
+      const testServicePath = 'testpath';
+      module.serverless.config.servicePath = testServicePath;
+      module.serverless.service.custom.webpack = testConfig;
+      serverless.utils.fileExistsSync = sinon.stub().returns(true);
+      return expect(module.validate()).to.be.rejected
+      .then(() => expect(serverless.cli.log).to.have.been.calledWith(sinon.match(/^Could not load webpack config/)));
+    });
   });
 
   describe('lib', () => {


### PR DESCRIPTION
## What did you implement:

This PR adds an extra log line if the webpack config file could not be loaded.
This makes the reason for errors in the configuration more clear than just printing the
actual exception without context.

## How did you implement it:

Added a try/catch around the `require()` of the configuration file.

## How can we verify it:

Implement a syntax error in your webpack config. Any try to package or deploy should mention
to the configuration file now before printing the error message or stacktrace.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
