### PR TITLE
Packaging in parallel instead of series

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -249,6 +249,8 @@ module.exports = {
           })
           .tap(() => this.options.verbose && this.serverless.cli.log(`Prune: ${modulePath} [${_.now() - startPrune} ms]`));
         });
+      }, {
+        concurrency: 5
       })
       .return(stats);
     });

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -210,7 +210,7 @@ module.exports = {
           reject(e);
         });
       })
-      .mapSeries(compileStats => {
+      .map(compileStats => {
         const modulePath = compileStats.compilation.compiler.outputPath;
 
         // Create package.json


### PR DESCRIPTION
## What did you implement:

Closes #236 

The goal is to execute in parallel the external modules packaging instead of doing it in series. This can increase the speed of the `serverless deploy` a lot if you have many functions.

## How did you implement it:

Just changing a array promise from series to parallel.

## How can we verify it:

Test still pass, and deploy still works on my side.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
