### PR TITLE
Do not let lodash parse module names as path elements

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -41,10 +41,10 @@ function getProdModules(externalModules, packagePath, dependencyGraph) {
       } catch (e) {
         this.serverless.cli.log(`WARNING: Could not check for peer dependencies of ${module.external}`);
       }
-    } else if (!_.has(packageJson, `devDependencies.${module.external}`)) {
+    } else if (!packageJson.devDependencies || !packageJson.devDependencies[module.external]) {
       // Add transient dependencies if they appear not in the service's dev dependencies
-      const originInfo = _.get(dependencyGraph, `dependencies.${module.origin}`, {});
-      moduleVersion = _.get(originInfo, `dependencies.${module.external}.version`);
+      const originInfo = _.get(dependencyGraph, 'dependencies', {})[module.origin] || {};
+      moduleVersion = _.get(_.get(originInfo, 'dependencies', {})[module.external], 'version');
       if (!moduleVersion) {
         this.serverless.cli.log(`WARNING: Could not determine version of module ${module.external}`);
       }
@@ -208,7 +208,8 @@ module.exports = {
           splitModule[0] = '@' + splitModule[0];
         }
         const moduleVersion = _.join(_.tail(splitModule), '@');
-        _.set(compositePackage, `dependencies.${_.first(splitModule)}`, moduleVersion);
+        compositePackage.dependencies = compositePackage.dependencies || {};
+        compositePackage.dependencies[_.first(splitModule)] = moduleVersion;
       });
       this.serverless.utils.writeFileSync(compositePackageJson, JSON.stringify(compositePackage, null, 2));
 


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #251

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Use full module name as property name and do not insert it into path elements used by lodash.
The previous implementation led to lodash splitting module names with dots to use them as paths.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Use a project with a dependency that contains a dot in its name.
The project should be packaged correctly, including the "dotted" dependency.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
