### PR TITLE
Make serverless-webpack more extensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,7 @@ WebPack's [Tree-Shaking][link-webpack-tree] optimization.
 
 ## Recent improvements
 
-* Support for individual packaging and optimization
-* Integrate with `serverless invoke local` (including watch mode)
-* Stabilized package handling
-* Improved compatibility with other plugins
-* Updated examples
+* Improved extensibility for plugin authors (see _For Developers_ section)
 
 For the complete release notes see the end of this document.
 
@@ -405,6 +401,59 @@ Plugin commands are supported by the following providers. ⁇ indicates that com
 | webpack               |      ✔︎     |         ✔︎        |        ⁇        |            ⁇           |
 | invoke local          |      ✔︎     |         ✔︎        |        ⁇        |            ⁇           |
 | invoke local --watch  |      ✔︎     |         ✔︎        |        ⁇        |            ⁇           |
+
+## For developers
+
+The plugin exposes a complete lifecycle model that can be hooked by other plugins to extend
+the functionality of the plugin or add additional actions.
+
+### The event lifecycles and their hookable events (H)
+
+All events (H) can be hooked by a plugin.
+
+```
+-> webpack:validate
+   -> webpack:validate:validate (H)
+-> webpack:compile
+   -> webpack:compile:compile (H)
+-> webpack:package
+   -> webpack:package:packExternalModules (H)
+   -> webpack:package:packageModules (H)
+```
+
+### Integration of the lifecycles into the command invocations and hooks
+
+The following list shows all lifecycles that are invoked/started by the
+plugin when running a command or invoked by a hook.
+
+```
+-> before:package:createDeploymentArtifacts
+   -> webpack:validate
+   -> webpack:compile
+   -> webpack:package
+
+-> before:deploy:function:packageFunction
+   -> webpack:validate
+   -> webpack:compile
+   -> webpack:package
+
+-> before:invoke:local:invoke
+   -> webpack:validate
+   -> webpack:compile
+
+-> webpack
+   -> webpack:validate
+   -> webpack:compile
+   -> webpack:package
+
+-> before:offline:start
+   -> webpack:validate
+   -> webpack:compile
+
+-> before:offline:start:init
+   -> webpack:validate
+   -> webpack:compile
+```
 
 ## Release Notes
 

--- a/index.js
+++ b/index.js
@@ -81,20 +81,12 @@ class ServerlessWebpack {
     };
 
     this.hooks = {
-      'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
-        .then(this.validate)
-        .then(this.compile)
-        .then(this.packExternalModules)
-        .then(this.packageModules),
+      'before:deploy:createDeploymentArtifacts': () => this.serverless.pluginManager.run(['webpack']),
 
       'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.cleanup),
 
-      'before:deploy:function:packageFunction': () => BbPromise.bind(this)
-        .then(this.validate)
-        .then(this.compile)
-        .then(this.packExternalModules)
-        .then(this.packageModules),
+      'before:deploy:function:packageFunction': () => this.serverless.pluginManager.run(['webpack']),
 
       'before:invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.validate)

--- a/index.js
+++ b/index.js
@@ -82,19 +82,17 @@ class ServerlessWebpack {
 
     this.hooks = {
       'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
-        .then(this.validate)
-        .then(this.compile)
-        .then(this.packExternalModules)
-        .then(this.packageModules),
+        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+        .then(() => this.serverless.pluginManager.spawn('webpack:package')),
 
       'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.cleanup),
 
       'before:deploy:function:packageFunction': () => BbPromise.bind(this)
-        .then(this.validate)
-        .then(this.compile)
-        .then(this.packExternalModules)
-        .then(this.packageModules),
+        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+        .then(() => this.serverless.pluginManager.spawn('webpack:package')),
 
       'before:invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.validate)

--- a/index.js
+++ b/index.js
@@ -95,8 +95,8 @@ class ServerlessWebpack {
         .then(() => this.serverless.pluginManager.spawn('webpack:package')),
 
       'before:invoke:local:invoke': () => BbPromise.bind(this)
-        .then(this.validate)
-        .then(this.compile)
+        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
         .then(this.prepareLocalInvoke),
 
       'after:invoke:local:invoke': () => BbPromise.bind(this)
@@ -129,12 +129,12 @@ class ServerlessWebpack {
 
       'before:offline:start': () => BbPromise.bind(this)
         .then(this.prepareOfflineInvoke)
-        .then(this.compile)
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
         .then(this.wpwatch),
 
       'before:offline:start:init': () => BbPromise.bind(this)
         .then(this.prepareOfflineInvoke)
-        .then(this.compile)
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
         .then(this.wpwatch),
 
     };

--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ class ServerlessWebpack {
       webpack: {
         usage: 'Bundle with Webpack',
         lifecycleEvents: [
-          'validate',
-          'compile',
+          'webpack'
         ],
         options: {
           out: {
@@ -58,22 +57,23 @@ class ServerlessWebpack {
           },
         },
         commands: {
-          invoke: {
-            usage: 'Run a function locally from the webpack output bundle',
+          validate: {
+            type: 'entrypoint',
             lifecycleEvents: [
-              'invoke',
+              'validate',
             ],
           },
-          watch: {
-            usage: 'Run a function from the webpack output bundle every time the source is changed',
+          compile: {
+            type: 'entrypoint',
             lifecycleEvents: [
-              'watch',
+              'compile',
             ],
           },
-          serve: {
-            usage: 'Simulate the API Gateway and serves lambdas locally',
+          package: {
+            type: 'entrypoint',
             lifecycleEvents: [
-              'serve',
+              'packExternalModules',
+              'packageModules'
             ],
           },
         },
@@ -81,12 +81,20 @@ class ServerlessWebpack {
     };
 
     this.hooks = {
-      'before:deploy:createDeploymentArtifacts': () => this.serverless.pluginManager.run(['webpack']),
+      'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.compile)
+        .then(this.packExternalModules)
+        .then(this.packageModules),
 
       'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.cleanup),
 
-      'before:deploy:function:packageFunction': () => this.serverless.pluginManager.run(['webpack']),
+      'before:deploy:function:packageFunction': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.compile)
+        .then(this.packExternalModules)
+        .then(this.packageModules),
 
       'before:invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.validate)
@@ -101,22 +109,25 @@ class ServerlessWebpack {
           return BbPromise.resolve();
         }),
 
-      'webpack:validate': () => BbPromise.bind(this)
+      'webpack:webpack': () => BbPromise.bind(this)
+        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+        .then(() => this.serverless.pluginManager.spawn('webpack:package')),
+
+      /*
+       * Internal webpack events (can be hooked by plugins)
+       */
+      'webpack:validate:validate': () => BbPromise.bind(this)
         .then(this.validate),
 
-      'webpack:compile': () => BbPromise.bind(this)
-        .then(this.compile)
-        .then(this.packExternalModules)
+      'webpack:compile:compile': () => BbPromise.bind(this)
+        .then(this.compile),
+
+      'webpack:package:packExternalModules': () => BbPromise.bind(this)
+        .then(this.packExternalModules),
+
+      'webpack:package:packageModules': () => BbPromise.bind(this)
         .then(this.packageModules),
-
-      'webpack:invoke:invoke': () => BbPromise.bind(this)
-        .then(() => BbPromise.reject(new this.serverless.classes.Error('Use "serverless invoke local" instead.'))),
-
-      'webpack:watch:watch': () => BbPromise.bind(this)
-        .then(() => BbPromise.reject(new this.serverless.classes.Error('Use "serverless invoke local --watch" instead.'))),
-
-      'webpack:serve:serve': () => BbPromise.bind(this)
-        .then(() => BbPromise.reject(new this.serverless.classes.Error('serve has been removed. Use serverless-offline instead.'))),
 
       'before:offline:start': () => BbPromise.bind(this)
         .then(this.prepareOfflineInvoke)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -37,8 +37,9 @@ module.exports = {
         });
 
         this.compileOutputPaths = compileOutputPaths;
+        this.compileStats = stats;
 
-        return stats;
+        return BbPromise.resolve();
       });
   },
 };

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -116,7 +116,9 @@ module.exports = {
    * This will utilize the npm cache at its best and give us the needed results
    * and performance.
    */
-  packExternalModules(stats) {
+  packExternalModules() {
+
+    const stats = this.compileStats;
 
     const includes = (
       this.serverless.service.custom &&
@@ -124,7 +126,7 @@ module.exports = {
     );
 
     if (!includes) {
-      return BbPromise.resolve(stats);
+      return BbPromise.resolve();
     }
 
     const packageForceIncludes = _.get(includes, 'forceInclude', []);
@@ -186,7 +188,7 @@ module.exports = {
       if (_.isEmpty(compositeModules)) {
         // The compiled code does not reference any external modules at all
         this.serverless.cli.log('No external modules needed');
-        return BbPromise.resolve(stats);
+        return BbPromise.resolve();
       }
 
       // (1.a) Install all needed modules
@@ -277,7 +279,7 @@ module.exports = {
           .tap(() => this.options.verbose && this.serverless.cli.log(`Prune: ${modulePath} [${_.now() - startPrune} ms]`));
         });
       })
-      .return(stats);
+      .return();
     });
   }
 };

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -77,7 +77,9 @@ function zip(directory, name) {
 }
 
 module.exports = {
-  packageModules(stats) {
+  packageModules() {
+    const stats = this.compileStats;
+
     return BbPromise.mapSeries(stats.stats, (compileStats, index) => {
       const entryFunction = _.get(this.entryFunctions, index, {});
       const filename = `${entryFunction.funcName || this.serverless.service.getServiceObject().name}.zip`;

--- a/lib/prepareOfflineInvoke.js
+++ b/lib/prepareOfflineInvoke.js
@@ -13,7 +13,7 @@ module.exports = {
     // Use service packaging for compile
     _.set(this.serverless, 'service.package.individually', false);
 
-    return this.validate()
+    return this.serverless.pluginManager.spawn('webpack:validate')
     .then(() => {
       // Set offline location automatically if not set manually
       if (!this.options.location && !_.get(this.serverless, 'service.custom.serverless-offline.location')) {

--- a/tests/packExternalModules.test.js
+++ b/tests/packExternalModules.test.js
@@ -497,7 +497,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.fulfilled
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.have.been.calledTwice,

--- a/tests/packExternalModules.test.js
+++ b/tests/packExternalModules.test.js
@@ -154,7 +154,8 @@ describe('packExternalModules', () => {
 
     it('should do nothing if webpackIncludeModules is not set', () => {
       _.unset(serverless, 'service.custom.webpackIncludeModules');
-      return expect(module.packExternalModules({ stats: [] })).to.eventually.deep.equal({ stats: [] })
+      module.compileStats = { stats: [] };
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         expect(fsExtraMock.copy).to.not.have.been.called,
         expect(childProcessMock.exec).to.not.have.been.called,
@@ -188,7 +189,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.fulfilled
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.have.been.calledTwice,
@@ -217,7 +219,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(new Error('npm install failed'));
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.rejectedWith('npm install failed')
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.rejectedWith('npm install failed')
       .then(() => BbPromise.all([
         // npm ls and npm install should have been called
         expect(childProcessMock.exec).to.have.been.calledTwice,
@@ -230,7 +233,8 @@ describe('packExternalModules', () => {
       fsExtraMock.pathExists.yields(null, false);
       fsExtraMock.copy.yields();
       childProcessMock.exec.yields(new Error('something went wrong'), '{}', stderr);
-      return expect(module.packExternalModules(stats)).to.be.rejectedWith('something went wrong')
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.rejectedWith('something went wrong')
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.not.have.been.called,
@@ -250,7 +254,8 @@ describe('packExternalModules', () => {
       fsExtraMock.pathExists.yields(null, false);
       fsExtraMock.copy.yields();
       childProcessMock.exec.yields(new Error('something went wrong'), '{}', stderr);
-      return expect(module.packExternalModules(stats)).to.be.rejectedWith('something went wrong')
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.rejectedWith('something went wrong')
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.not.have.been.called,
@@ -311,7 +316,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(new Error('NPM error'), JSON.stringify(lsResult), stderr);
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.fulfilled
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.have.been.calledTwice,
@@ -338,9 +344,9 @@ describe('packExternalModules', () => {
       module.webpackOutputPath = 'outputPath';
       fsExtraMock.copy.yields();
       childProcessMock.exec.yields(null, '{}', '');
-      return expect(module.packExternalModules(noExtStats)).to.be.fulfilled
-      .then(stats => BbPromise.all([
-        expect(stats).to.deep.equal(noExtStats),
+      module.compileStats = noExtStats;
+      return expect(module.packExternalModules()).to.be.fulfilled
+      .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.not.have.been.called,
         // The modules should have been copied
@@ -382,7 +388,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.fulfilled
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.have.been.calledTwice,
@@ -436,7 +443,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.fulfilled
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.have.been.calledTwice,
@@ -484,7 +492,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.fulfilled
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.have.been.calledTwice,
@@ -536,7 +545,8 @@ describe('packExternalModules', () => {
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
-      return expect(module.packExternalModules(stats)).to.be.fulfilled
+      module.compileStats = stats;
+      return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
         expect(writeFileSyncStub).to.have.been.calledTwice,
@@ -618,7 +628,8 @@ describe('packExternalModules', () => {
         childProcessMock.exec.onFirstCall().yields(null, JSON.stringify(dependencyGraph), '');
         childProcessMock.exec.onSecondCall().yields(null, '', '');
         childProcessMock.exec.onThirdCall().yields();
-        return expect(module.packExternalModules(peerDepStats)).to.be.fulfilled
+        module.compileStats = peerDepStats;
+        return expect(module.packExternalModules()).to.be.fulfilled
         .then(() => BbPromise.all([
           // The module package JSON and the composite one should have been stored
           expect(writeFileSyncStub).to.have.been.calledTwice,

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -83,7 +83,8 @@ describe('packageModules', () => {
 
   describe('packageModules()', () => {
     it('should do nothing if no compile stats are available', () => {
-      return expect(module.packageModules({ stats: [] })).to.be.fulfilled
+      module.compileStats = { stats: [] };
+      return expect(module.packageModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         expect(archiverMock.create).to.not.have.been.called,
         expect(writeFileDirStub).to.not.have.been.called,
@@ -141,7 +142,8 @@ describe('packageModules', () => {
 
         const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
 
-        return expect(module.packageModules(stats)).to.be.fulfilled
+        module.compileStats = stats;
+        return expect(module.packageModules()).to.be.fulfilled
         .then(() => BbPromise.all([
           expect(func1).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
           expect(func2).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
@@ -206,7 +208,8 @@ describe('packageModules', () => {
 
           const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
 
-          return expect(module.packageModules(stats)).to.be.fulfilled
+          module.compileStats = stats;
+          return expect(module.packageModules()).to.be.fulfilled
           .then(() => expect(serverless.service).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath));
         });
       });
@@ -252,9 +255,10 @@ describe('packageModules', () => {
 
         const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
 
+        module.compileStats = stats;
         return BbPromise.each([ '1.18.1', '2.17.0', '10.15.3', ], version => {
           getVersionStub.returns(version);
-          return expect(module.packageModules(stats)).to.be.fulfilled
+          return expect(module.packageModules()).to.be.fulfilled
           .then(() => BbPromise.all([
             expect(func1).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
             expect(func2).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
@@ -262,7 +266,7 @@ describe('packageModules', () => {
         })
         .then(() => BbPromise.each([ '1.17.0', '1.16.0-alpha', '1.15.3', ], version => {
           getVersionStub.returns(version);
-          return expect(module.packageModules(stats)).to.be.fulfilled
+          return expect(module.packageModules()).to.be.fulfilled
           .then(() => BbPromise.all([
             expect(func1).to.have.a.nested.property('artifact').that.equals(expectedArtifactPath),
             expect(func2).to.have.a.nested.property('artifact').that.equals(expectedArtifactPath),
@@ -310,7 +314,8 @@ describe('packageModules', () => {
         fsMock._streamMock.on.withArgs('close').yields();
         fsMock._statMock.isDirectory.returns(false);
 
-        return expect(module.packageModules(stats)).to.be.rejectedWith('Packaging: No files found');
+        module.compileStats = stats;
+        return expect(module.packageModules()).to.be.rejectedWith('Packaging: No files found');
       });
     });
 
@@ -381,7 +386,8 @@ describe('packageModules', () => {
         fsMock._streamMock.on.withArgs('close').yields();
         fsMock._statMock.isDirectory.returns(false);
 
-        return expect(module.packageModules(stats)).to.be.fulfilled
+        module.compileStats = stats;
+        return expect(module.packageModules()).to.be.fulfilled
         .then(() => BbPromise.all([
           expect(func1).to.have.a.nested.property('package.artifact').that.equals(path.join('.serverless', 'func1.zip')),
           expect(func2).to.have.a.nested.property('package.artifact').that.equals(path.join('.serverless', 'func2.zip')),


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Use PluginManager to make serverless-webpack more extensible. I am trying to create my own plugin that works with serverless-webpack, but I am unable to extend before the validation step without this change.

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:
Following the advice from serverless blog on Advanced Plugin Development. Used Plugin Manager. 
https://serverless.com/blog/advanced-plugin-development-extending-the-core-lifecycle/

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
As stated in the blog above... this will enable better extensibility. 
Try to create a new serverless plugin that runs before the serverless-webpack before:deploy:createDeploymentArtifacts hook. 

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
