### PR TITLE
Support skipping webpack on a per function basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ module.exports = {
 };
 ```
 
+#### Non JS functions
+
+You can mix and match a project with different runtimes and serverless-webpack
+will do the right thing. However, you must package individually for this to
+work.
+
+```yaml
+# serverless.yml
+...
+package:
+  individually: true
+...
+```
+
 #### Full customization (for experts)
 
 The lib export also provides the `serverless` and `options` properties, through

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -3,9 +3,14 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
+const helpers = require('./helpers');
 
 module.exports = {
   compile() {
+    if (helpers.hasEmptyWebpackConfig(this.webpackConfig)) {
+      return BbPromise.resolve();
+    }
+
     this.serverless.cli.log('Bundling with Webpack...');
 
     const compiler = webpack(this.webpackConfig);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const _ = require('lodash');
+
+function hasNodeRuntime(funcName, serverless) {
+  const serverlessFunction = serverless.service.getFunction(funcName);
+  const runtime = serverlessFunction.runtime || serverless.service.provider.runtime;
+
+  return !runtime || /^nodejs/.test(runtime);
+}
+
+function hasEmptyWebpackConfig(config) {
+  return (_.isEmpty(config) || (!_.isArray(config) && _.isEmpty(config.entry)));
+}
+
+module.exports = {
+  hasNodeRuntime,
+  hasEmptyWebpackConfig,
+};

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -6,6 +6,7 @@ const path = require('path');
 const childProcess = require('child_process');
 const fse = require('fs-extra');
 const isBuiltinModule = require('is-builtin-module');
+const helpers = require('./helpers');
 
 /**
  * Add the given modules to a package json's dependencies.
@@ -159,6 +160,9 @@ module.exports = {
    * and performance.
    */
   packExternalModules() {
+    if (helpers.hasEmptyWebpackConfig(this.webpackConfig)) {
+      return BbPromise.resolve();
+    }
 
     const stats = this.compileStats;
 

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -7,6 +7,7 @@ const archiver = require('archiver');
 const fs = require('fs');
 const glob = require('glob');
 const semver = require('semver');
+const helpers = require('./helpers');
 
 function setArtifactPath(funcName, func, artifactPath) {
   const version = this.serverless.getVersion();
@@ -78,6 +79,10 @@ function zip(directory, name) {
 
 module.exports = {
   packageModules() {
+    if (helpers.hasEmptyWebpackConfig(this.webpackConfig)) {
+      return BbPromise.resolve();
+    }
+
     const stats = this.compileStats;
 
     return BbPromise.mapSeries(stats.stats, (compileStats, index) => {

--- a/lib/prepareLocalInvoke.js
+++ b/lib/prepareLocalInvoke.js
@@ -3,9 +3,14 @@
 const BbPromise = require('bluebird');
 const path = require('path');
 const _ = require('lodash');
+const helpers = require('./helpers');
 
 module.exports = {
   prepareLocalInvoke() {
+    if (!helpers.hasNodeRuntime(this.options.function, this.serverless)) {
+      return BbPromise.resolve();
+    }
+
     const originalPath = this.serverless.config.serverless.processedInput.options.path;
     if (originalPath) {
       const absolutePath = path.resolve(originalPath);

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,12 +3,18 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
+const helpers = require('./helpers');
 
 module.exports = {
   watch(command) {
     const functionName = this.options.function;
+
     if (functionName) {
       this.serverless.cli.log(`Watch function ${functionName}...`);
+
+      if (!helpers.hasNodeRuntime(functionName, this.serverless)) {
+        return BbPromise.resolve();
+      }
     } else {
       this.serverless.cli.log('Watch service...');
     }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -6,6 +6,7 @@ const fse = require('fs-extra');
 const glob = require('glob');
 const lib = require('./index');
 const _ = require('lodash');
+const helpers = require('./helpers');
 
 /**
  * For automatic entry detection we sort the found files to solve ambiguities.
@@ -56,7 +57,6 @@ module.exports = {
       }
       return path.extname(_.first(sortedFiles));
     };
-
     const getEntryForFunction = (name, serverlessFunction) => {
       const handler = serverlessFunction.handler;
 
@@ -84,14 +84,21 @@ module.exports = {
     const entries = {};
 
     const functions = this.serverless.service.getAllFunctions();
+
     if (this.options.function) {
-      const serverlessFunction = this.serverless.service.getFunction(this.options.function);
-      const entry = getEntryForFunction.call(this, this.options.function, serverlessFunction);
-      _.merge(entries, entry);
-    } else {
-      _.forEach(functions, (func, index) => {
-        const entry = getEntryForFunction.call(this, functions[index], this.serverless.service.getFunction(func));
+      const functionName = this.options.function;
+      if (helpers.hasNodeRuntime(functionName, this.serverless)) {
+        const serverlessFunction = this.serverless.service.getFunction(functionName);
+        const entry = getEntryForFunction.call(this, this.options.function, serverlessFunction);
         _.merge(entries, entry);
+      }
+    } else {
+      _.forEach(functions, (functionName, index) =>  {
+        if (helpers.hasNodeRuntime(functionName, this.serverless)) {
+          const serverlessFunction = this.serverless.service.getFunction(functionName);
+          const entry = getEntryForFunction.call(this, functions[index], serverlessFunction);
+          _.merge(entries, entry);
+        }
       });
     }
 

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -3,9 +3,14 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
+const helpers = require('./helpers');
 
 module.exports = {
   wpwatch() {
+    if (helpers.hasEmptyWebpackConfig(this.webpackConfig)) {
+      return BbPromise.resolve();
+    }
+
     if (this.options['webpack-no-watch']) {
       // If we do not watch we will just run an ordinary compile
       this.serverless.cli.log('Watch disabled by option.');

--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -60,7 +60,7 @@ describe('compile', () => {
   });
 
   it('should compile with webpack from a context configuration', () => {
-    const testWebpackConfig = 'testconfig';
+    const testWebpackConfig = [{ not: 'empty' }];
     module.webpackConfig = testWebpackConfig;
     return expect(module.compile()).to.be.fulfilled
     .then(() => {
@@ -71,14 +71,14 @@ describe('compile', () => {
   });
 
   it('should fail if there are compilation errors', () => {
-    module.webpackConfig = 'testconfig';
+    module.webpackConfig = [{ not: 'empty' }];
     // We stub errors here. It will be reset again in afterEach()
     sandbox.stub(webpackMock.statsMock.compilation, 'errors').value(['error']);
     return expect(module.compile()).to.be.rejectedWith(/compilation error/);
   });
 
   it('should work with multi compile', () => {
-    const testWebpackConfig = 'testconfig';
+    const testWebpackConfig = [{ not: 'empty' }];
     const multiStats = [{
       compilation: {
         errors: [],
@@ -102,7 +102,8 @@ describe('compile', () => {
 
   it('should use correct stats option', () => {
     const testWebpackConfig = {
-      stats: 'minimal'
+      stats: 'minimal',
+      entry: { not: 'empty' }
     };
     const mockStats = {
       compilation: {

--- a/tests/packExternalModules.test.js
+++ b/tests/packExternalModules.test.js
@@ -66,6 +66,7 @@ describe('packExternalModules', () => {
       options: {
         verbose: true
       },
+      webpackConfig: [{ not: 'empty' }],
     }, baseModule);
   });
 

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -72,6 +72,7 @@ describe('packageModules', () => {
     module = _.assign({
       serverless,
       options: {},
+      webpackConfig: [{ not: 'empty' }],
     }, baseModule);
   });
 

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -81,6 +81,7 @@ describe('run', () => {
       const watch = module.watch.bind(module);
       webpackMock.compilerMock.watch = sandbox.stub().yields(null, {});
       _.set(module, 'options.function', 'myFunction');
+      _.set(module, 'serverless.service.functions', { 'myFunction': {} });
 
       watch('invoke:local');
       expect(spawnStub).to.not.have.been.called;

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -385,6 +385,18 @@ describe('validate', () => {
         },
       };
 
+      const testFunctionsWebpackFalseConfig = {
+        func1: {
+          handler: 'module1.func1handler',
+          artifact: 'artifact-func1.zip',
+        },
+        func2: {
+          handler: 'module2.func2handler',
+          artifact: 'artifact-func2.zip',
+          runtime: 'python2.7',
+        },
+      };
+
       it('should expose all functions if `options.function` is not defined', () => {
         const testOutPath = 'test';
         const testConfig = {
@@ -409,6 +421,32 @@ describe('validate', () => {
 
           expect(lib.entries).to.deep.equal(expectedLibEntries);
           expect(globSyncStub).to.have.callCount(4);
+          expect(serverless.cli.log).to.not.have.been.called;
+          return null;
+        });
+      });
+
+      it('should not expose any functions where a node based runtime isn\'t being used', () => {
+        const testOutPath = 'test';
+        const testConfig = {
+          entry: 'test',
+          context: 'testcontext',
+          output: {
+            path: testOutPath,
+          },
+        };
+        module.serverless.service.custom.webpack = testConfig;
+        module.serverless.service.functions = testFunctionsWebpackFalseConfig;
+        globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
+        return expect(module.validate()).to.be.fulfilled
+        .then(() => {
+          const lib = require('../lib/index');
+          const expectedLibEntries = {
+            'module1': './module1.js',
+          };
+
+          expect(lib.entries).to.deep.equal(expectedLibEntries);
+          expect(globSyncStub).to.have.callCount(1);
           expect(serverless.cli.log).to.not.have.been.called;
           return null;
         });

--- a/tests/wpwatch.test.js
+++ b/tests/wpwatch.test.js
@@ -59,7 +59,8 @@ describe('wpwatch', function() {
     spawnStub = sandbox.stub(serverless.pluginManager, 'spawn');
 
     const webpackConfig = {
-      stats: 'minimal'
+      stats: 'minimal',
+      entry: { not: 'empty' }
     };
     _.set(module, 'webpackConfig', webpackConfig);
   });


### PR DESCRIPTION
## What did you implement:

Closes #255

## How did you implement it:

We add ```webpack: false``` to functions where we want to skip webpack.
In ```index.js``` in the relevant hooks we check if this is set and just return. This will run the original hook.

## How can we verify it:

Examples:
In serverless.yml add a function similar to
```yaml
functions:
  get_oai:
    runtime: python2.7
    handler: src/oai.handler
    webpack: false
```

run ```sls deploy -f get_oai``` and the .serverless/get_oai.zip should contain everything in the project. Webpack will not run

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
