### PR TITLE
Allow webpack stats option to overwrite default behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ module.exports = {
 };
 ```
 
+### Stats
+
+By default, the plugin will print a quite verbose bundle information to your console. However, if 
+you are not satisfy with the current output info, you can overwrite it in your `webpack.config.js`
+
+```js
+// webpack.config.js
+
+module.export = {
+  // ...
+  stats: 'minimal'
+  // ...
+}
+```
+
+All the stats config can be found in [webpack's documentation](https://webpack.js.org/configuration/stats/)
+
+
 ### Node modules / externals
 
 By default, the plugin will try to bundle all dependencies. However, you don't

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -19,15 +19,16 @@ module.exports = {
         }
 
         const compileOutputPaths = [];
+        const consoleStats = this.webpackConfig.stats || {
+          colors: true,
+          hash: false,
+          version: false,
+          chunks: false,
+          children: false
+        };
 
         _.forEach(stats.stats, compileStats => {
-          this.serverless.cli.consoleLog(compileStats.toString({
-            colors: true,
-            hash: false,
-            version: false,
-            chunks: false,
-            children: false
-          }));
+          this.serverless.cli.consoleLog(compileStats.toString(consoleStats));
 
           if (compileStats.compilation.errors.length) {
             throw new Error('Webpack compilation error, see above');

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -22,7 +22,7 @@ module.exports = {
       }
 
       if (stats) {
-        console.log(stats.toString());   // eslint-disable-line no-console
+        this.serverless.cli.consoleLog(stats.toString(this.webpackConfig.stats));
       }
     });
 


### PR DESCRIPTION
## What did you implement:

Closes #260

## How did you implement it:

When console log the compile stats, if webpack.config.js has stats configured, use it. Otherwise use default behaviour.

## How can we verify it:

Using example/serverless-offline with default config:

![image](https://user-images.githubusercontent.com/20551609/32051439-54b6fc72-baa0-11e7-987f-1fab9fe8d27f.png)

After add `stats: 'minimal'` to webpack config:
![image](https://user-images.githubusercontent.com/20551609/32051499-8b2eb9e8-baa0-11e7-8040-61e93d4b50ec.png)



## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
