### PR TITLE
Update README.md to fix sample config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ for best compatibility with external dependencies:
 
 ```js
 // webpack.config.js
+const path = require('path');
 
 module.exports = {
   // ...
   output: {
     libraryTarget: 'commonjs',
-    path: '.webpack',
+    path: path.resolve(__dirname, '.webpack'),
     filename: 'handler.js', // this should match the first part of function handler in `serverless.yml`
   },
   // ...

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ module.exports = {
   output: {
     libraryTarget: 'commonjs',
     path: path.resolve(__dirname, '.webpack'),
-    filename: 'handler.js', // this should match the first part of function handler in `serverless.yml`
+    filename: '[name].js',
   },
   // ...
 };
@@ -147,7 +147,7 @@ module.exports = {
 
 ### Stats
 
-By default, the plugin will print a quite verbose bundle information to your console. However, if 
+By default, the plugin will print a quite verbose bundle information to your console. However, if
 you are not satisfy with the current output info, you can overwrite it in your `webpack.config.js`
 
 ```js


### PR DESCRIPTION
Path needs to be an absolute path since webpack 2.3.1 current sample code in documentation will not run.

`- configuration.output.path: The provided value ".webpack/service" is not an absolute path!`

<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Fix for a sample in the documentation, webpack requires `path` to be absolute.

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

Starting with the sample code, I adjusted it so it worked. using path.resolve to resolve the abs path for web pack.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Check that sample correctly runs by running the webpack.config.js

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [X] Write documentation
- [ ] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
