### PR TITLE
Default entry individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ result, the deployed artifacts are smaller, depending on the functions and
 cold-start times (to install the functions into the cloud at runtime) are reduced
 too.
 
-The individual packaging should be combined with the _automatic entry resolution_ (see above).
+The individual packaging will automatically apply the _automatic entry resolution_ (see above) and
+you will not be able to configure the entry config in webpack. An error will be thrown
+if you are trying to override the entry in webpack.config.js with other unsupported values.
 
 The individual packaging needs more time at the packaging phase, but you'll
 get that paid back twice at runtime.

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -135,6 +135,12 @@ module.exports = {
       this.options.verbose && this.serverless.cli.log('Using multi-compile (individual packaging)');
       this.multiCompile = true;
 
+      if (this.webpackConfig.entry && !_.isEqual(this.webpackConfig.entry, entries)) {
+        throw new this.serverless.classes
+          .Error('Webpack entry must be automatically resolved when package.individually is set to true. ' +
+            'In webpack.config.js, remove the entry declaration or set entry to slsw.lib.entries.');
+      }
+
       // Lookup associated Serverless functions
       const allEntryFunctions = _.map(
         this.serverless.service.getAllFunctions(),

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -21,6 +21,14 @@ const preferredExtensions = [
 
 module.exports = {
   validate() {
+    const getHandlerFile = handler => {
+      // Check if handler is a well-formed path based handler.
+      const handlerEntry = /(.*)\..*?$/.exec(handler);
+      if (handlerEntry) {
+        return handlerEntry[1];
+      }
+    };
+
     const getEntryExtension = fileName => {
       const files = glob.sync(`${fileName}.*`, {
         cwd: this.serverless.config.servicePath,
@@ -51,14 +59,13 @@ module.exports = {
 
     const getEntryForFunction = (name, serverlessFunction) => {
       const handler = serverlessFunction.handler;
-      // Check if handler is a well-formed path based handler.
-      const handlerEntry = /(.*)\..*?$/.exec(handler);
-      if (!handlerEntry) {
+      
+      const handlerFile = getHandlerFile(handler);
+      if (!handlerFile) {
         _.get(this.serverless, 'service.provider.name') !== 'google' &&
           this.serverless.cli.log(`\nWARNING: Entry for ${name}@${handler} could not be retrieved.\nPlease check your service config if you want to use lib.entries.`);
         return {};
       }
-      const handlerFile = handlerEntry[1];
       const ext = getEntryExtension(handlerFile);
 
       // Create a valid entry key
@@ -147,7 +154,7 @@ module.exports = {
         funcName => {
           const func = this.serverless.service.getFunction(funcName);
           const handler = func.handler;
-          const handlerFile = path.relative('.', /(.*)\..*?$/.exec(handler)[1]);
+          const handlerFile = path.relative('.', getHandlerFile(handler));
           return {
             handlerFile,
             funcName,

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -150,7 +150,7 @@ module.exports = {
         }
       );
 
-      this.entryFunctions = _.flatMap(this.webpackConfig.entry, (value, key) => {
+      this.entryFunctions = _.flatMap(entries, (value, key) => {
         const entry = path.relative('.', value);
         const entryFile = _.replace(entry, new RegExp(`${path.extname(entry)}$`), '');
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -143,9 +143,9 @@ module.exports = {
       this.multiCompile = true;
 
       if (this.webpackConfig.entry && !_.isEqual(this.webpackConfig.entry, entries)) {
-        throw new this.serverless.classes
+        return BbPromise.reject(new this.serverless.classes
           .Error('Webpack entry must be automatically resolved when package.individually is set to true. ' +
-            'In webpack.config.js, remove the entry declaration or set entry to slsw.lib.entries.');
+            'In webpack.config.js, remove the entry declaration or set entry to slsw.lib.entries.'));
       }
 
       // Lookup associated Serverless functions

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -463,7 +463,7 @@ describe('validate', () => {
           });
         });
 
-        it('should throw an exception if webpackConfig.entry is customised', () => {
+        it('should fail if webpackConfig.entry is customised', () => {
           module.serverless.service.custom.webpack = _.merge({}, testConfig, {
             entry: {
               module1: './module1.js',
@@ -472,21 +472,18 @@ describe('validate', () => {
           });
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
-          expect(() => {
-            module.validate();
-          }).to.throw(/Webpack entry must be automatically resolved when package.individually is set to true/);
+          return expect(module.validate()).to.be.rejectedWith(
+            /Webpack entry must be automatically resolved when package.individually is set to true/);
         });
 
-        it('should not throw an exception if webpackConfig.entry is set to lib.entries for backward compatibility', () => {
+        it('should not fail if webpackConfig.entry is set to lib.entries for backward compatibility', () => {
           const lib = require('../lib/index');
           module.serverless.service.custom.webpack = _.merge({}, testConfig, {
             entry: lib.entries
           });
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
-          expect(() => {
-            module.validate();
-          }).to.not.throw();
+          return expect(module.validate()).to.be.fulfilled;
         });
 
         it('should expose all functions details in entryFunctions property', () => {

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -436,12 +436,6 @@ describe('validate', () => {
 
       describe('package individually', () => {
         const testConfig = {
-          entry: {
-            module1: './module1.js',
-            module2: './module2.js',
-            'handlers/func3/module2': './handlers/func3/module2.js',
-            'handlers/module2/func3/module2': './handlers/module2/func3/module2.js'
-          },
           output: {
             path: 'output',
           },

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -463,6 +463,32 @@ describe('validate', () => {
           });
         });
 
+        it('should throw an exception if webpackConfig.entry is customised', () => {
+          module.serverless.service.custom.webpack = _.merge({}, testConfig, {
+            entry: {
+              module1: './module1.js',
+              module2: './module2.js'
+            }
+          });
+          module.serverless.service.functions = testFunctionsConfig;
+          globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
+          expect(() => {
+            module.validate();
+          }).to.throw(/Webpack entry must be automatically resolved when package.individually is set to true/);
+        });
+
+        it('should not throw an exception if webpackConfig.entry is set to lib.entries for backward compatibility', () => {
+          const lib = require('../lib/index');
+          module.serverless.service.custom.webpack = _.merge({}, testConfig, {
+            entry: lib.entries
+          });
+          module.serverless.service.functions = testFunctionsConfig;
+          globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
+          expect(() => {
+            module.validate();
+          }).to.not.throw();
+        });
+
         it('should expose all functions details in entryFunctions property', () => {
           module.serverless.service.custom.webpack = testConfig;
           module.serverless.service.functions = testFunctionsConfig;


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #272.

Mainly:
- Default webpackConfig entry to lib.entries if package.individually is set to true.
- Throw error if entry is set to anything else other than empty value or lib.entries.

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Trivial change.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->
New behaviour can be seen in the unit tests.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO (Do assess)
