### PR TITLE
fix compile stats in multiple packaging

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -14,18 +14,26 @@ module.exports = {
       .fromCallback(cb => compiler.run(cb))
       .then(stats => {
 
-        if (!this.multiCompile) {
-          stats = { stats: [stats] };
-        }
-
-        const compileOutputPaths = [];
-        const consoleStats = this.webpackConfig.stats || {
+        let consoleStats = {
           colors: true,
           hash: false,
           version: false,
           chunks: false,
           children: false
         };
+
+        if (!this.multiCompile) {
+          stats = { stats: [stats] };
+          if (_.has(this.webpackConfig, 'stats')) {
+            consoleStats = this.webpackConfig.stats;
+          }
+        } else {
+          if (_.has(this.webpackConfig, '0.stats')) {
+            consoleStats = this.webpackConfig[0].stats;
+          }
+        }
+
+        const compileOutputPaths = [];
 
         _.forEach(stats.stats, compileStats => {
           this.serverless.cli.consoleLog(compileStats.toString(consoleStats));


### PR DESCRIPTION
## What did you implement:

Fix a problem of [#261](https://github.com/serverless-heaven/serverless-webpack/pull/261#issuecomment-344437763)

## How did you implement it:
Check `multiCompile` flag to extract the correct stats option

## How can we verify it:


## Todos:

- [ ] Write tests
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO: Need to run some manual test/write tests
***Is it a breaking change?:*** NO
