### PR TITLE
Fix/Support npm file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ custom:
 If you specify a module in both arrays, `forceInclude` and `forceExclude`, the
 exclude wins and the module will not be packaged.
 
+#### Local modules
+
+You can use `file:` version references in your `package.json` to use a node module
+from a local folder (e.g. `"mymodule": "file:../../myOtherProject/mymodule"`).
+With that you can do test deployments from the local machine with different
+module versions or modules before they are published officially.
+
 #### Examples
 
 You can find an example setups in the [`examples`][link-examples] folder.

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -20,7 +20,7 @@ function addModulesToPackageJson(externalModules, packageJson, pathToPackageRoot
     }
     let moduleVersion = _.join(_.tail(splitModule), '@');
     // We have to rebase file references to the target package.json
-    if (_.startsWith(moduleVersion, 'file:')) {
+    if (/^file:[^/]{2}/.test(moduleVersion)) {
       const filePath = _.replace(moduleVersion, /^file:/, '');
       moduleVersion = _.replace(`file:${pathToPackageRoot}/${filePath}`, /\\/g, '/');
     }

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -7,6 +7,27 @@ const childProcess = require('child_process');
 const fse = require('fs-extra');
 const isBuiltinModule = require('is-builtin-module');
 
+function rebaseFileReferences(pathToPackageRoot, moduleVersion) {
+  if (/^file:[^/]{2}/.test(moduleVersion)) {
+    const filePath = _.replace(moduleVersion, /^file:/, '');
+    return _.replace(`file:${pathToPackageRoot}/${filePath}`, /\\/g, '/');
+  }
+
+  return moduleVersion;
+}
+
+function rebasePackageLock(pathToPackageRoot, module) {
+  if (module.version) {
+    module.version = rebaseFileReferences(pathToPackageRoot, module.version);
+  }
+
+  if (module.dependencies) {
+    _.forIn(module.dependencies, moduleDependency => {
+      rebasePackageLock(pathToPackageRoot, moduleDependency);
+    });
+  }
+}
+
 /**
  * Add the given modules to a package json's dependencies.
  */
@@ -20,10 +41,7 @@ function addModulesToPackageJson(externalModules, packageJson, pathToPackageRoot
     }
     let moduleVersion = _.join(_.tail(splitModule), '@');
     // We have to rebase file references to the target package.json
-    if (/^file:[^/]{2}/.test(moduleVersion)) {
-      const filePath = _.replace(moduleVersion, /^file:/, '');
-      moduleVersion = _.replace(`file:${pathToPackageRoot}/${filePath}`, /\\/g, '/');
-    }
+    moduleVersion = rebaseFileReferences(pathToPackageRoot, moduleVersion);
     packageJson.dependencies = packageJson.dependencies || {};
     packageJson.dependencies[_.first(splitModule)] = moduleVersion;
   });
@@ -262,8 +280,21 @@ module.exports = {
       .then(exists => {
         if (exists) {
           this.serverless.cli.log('Package lock found - Using locked versions');
-          return BbPromise.fromCallback(cb => fse.copy(packageLockPath, path.join(compositeModulePath, 'package-lock.json'), cb))
-          .catch(err => this.serverless.cli.log(`Warning: Could not copy lock file: ${err.message}`));
+          try {
+            const packageLockJson = this.serverless.utils.readFileSync(packageLockPath);
+            /**
+             * We should not be modifying 'package-lock.json'
+             * because this file should be treat as internal to npm.
+             * 
+             * Rebase package-lock is a temporary workaround and must be
+             * removed as soon as https://github.com/npm/npm/issues/19183 gets fixed.
+             */
+            rebasePackageLock(relPath, packageLockJson);
+
+            this.serverless.utils.writeFileSync(path.join(compositeModulePath, 'package-lock.json'), JSON.stringify(packageLockJson, null, 2));
+          } catch(err) {
+            this.serverless.cli.log(`Warning: Could not read lock file: ${err.message}`);
+          }
         }
         return BbPromise.resolve();
       })

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -10,7 +10,7 @@ const isBuiltinModule = require('is-builtin-module');
 /**
  * Add the given modules to a package json's dependencies.
  */
-function addModulesToPackageJson(externalModules, packageJson) {
+function addModulesToPackageJson(externalModules, packageJson, pathToPackageRoot) {
   _.forEach(externalModules, externalModule => {
     const splitModule = _.split(externalModule, '@');
     // If we have a scoped module we have to re-add the @
@@ -18,7 +18,12 @@ function addModulesToPackageJson(externalModules, packageJson) {
       splitModule.splice(0, 1);
       splitModule[0] = '@' + splitModule[0];
     }
-    const moduleVersion = _.join(_.tail(splitModule), '@');
+    let moduleVersion = _.join(_.tail(splitModule), '@');
+    // We have to rebase file references to the target package.json
+    if (_.startsWith(moduleVersion, 'file:')) {
+      const filePath = _.replace(moduleVersion, /^file:/, '');
+      moduleVersion = _.replace(`file:${pathToPackageRoot}/${filePath}`, /\\/g, '/');
+    }
     packageJson.dependencies = packageJson.dependencies || {};
     packageJson.dependencies[_.first(splitModule)] = moduleVersion;
   });
@@ -247,7 +252,8 @@ module.exports = {
         description: `Packaged externals for ${this.serverless.service.service}`,
         private: true
       };
-      addModulesToPackageJson(compositeModules, compositePackage);
+      const relPath = path.relative(compositeModulePath, path.dirname(packageJsonPath));
+      addModulesToPackageJson(compositeModules, compositePackage, relPath);
       this.serverless.utils.writeFileSync(compositePackageJson, JSON.stringify(compositePackage, null, 2));
 
       // (1.a.2) Copy package-lock.json if it exists, to prevent unwanted upgrades
@@ -288,7 +294,8 @@ module.exports = {
             _.map(packageForceIncludes, whitelistedPackage => ({ external: whitelistedPackage }))
           ), packagePath, dependencyGraph);
         removeExcludedModules.call(this, prodModules, packageForceExcludes);
-        addModulesToPackageJson(prodModules, modulePackage);
+        const relPath = path.relative(modulePath, path.dirname(packageJsonPath));
+        addModulesToPackageJson(prodModules, modulePackage, relPath);
         this.serverless.utils.writeFileSync(modulePackageJson, JSON.stringify(modulePackage, null, 2));
 
         // GOOGLE: Copy modules only if not google-cloud-functions

--- a/tests/mocks/packageLocalRef.mock.json
+++ b/tests/mocks/packageLocalRef.mock.json
@@ -1,0 +1,33 @@
+{
+  "dependencies": {
+    "archiver": "^2.0.0",
+    "bluebird": "^3.4.0",
+    "fs-extra": "^0.26.7",
+    "glob": "^7.1.2",
+    "localmodule": "file:../../mymodule",
+    "lodash": "^4.17.4",
+    "npm-programmatic": "0.0.5",
+    "uuid": "^5.4.1",
+    "ts-node": "^3.2.0",
+    "@scoped/vendor": "1.0.0",
+    "pg": "^4.3.5"
+  },
+  "devDependencies": {
+    "babel-eslint": "^7.2.3",
+    "chai": "^4.1.0",
+    "chai-as-promised": "^7.1.1",
+    "eslint": "^4.3.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-lodash": "^2.4.4",
+    "eslint-plugin-promise": "^3.5.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.4.2",
+    "mockery": "^2.1.0",
+    "serverless": "^1.17.0",
+    "sinon": "^2.3.8",
+    "sinon-chai": "^2.12.0"
+  },
+  "peerDependencies": {
+    "webpack": "*"
+  }
+}

--- a/tests/packExternalModules.test.js
+++ b/tests/packExternalModules.test.js
@@ -30,6 +30,7 @@ describe('packExternalModules', () => {
   let fsExtraMock;
   // Serverless stubs
   let writeFileSyncStub;
+  let readFileSyncStub;
 
   before(() => {
     sandbox = sinon.sandbox.create();
@@ -60,6 +61,7 @@ describe('packExternalModules', () => {
     _.set(serverless, 'service.service', 'test-service');
 
     writeFileSyncStub = sandbox.stub(serverless.utils, 'writeFileSync');
+    readFileSyncStub = sandbox.stub(serverless.utils, 'readFileSync');
     _.set(serverless, 'service.custom.webpackIncludeModules', true);
 
     module = _.assign({
@@ -73,6 +75,7 @@ describe('packExternalModules', () => {
   afterEach(() => {
     // Reset all counters and restore all stubbed functions
     writeFileSyncStub.reset();
+    readFileSyncStub.reset();
     childProcessMock.exec.reset();
     fsExtraMock.pathExists.reset();
     fsExtraMock.copy.reset();
@@ -258,6 +261,7 @@ describe('packExternalModules', () => {
     });
 
     it('should rebase file references', () => {
+      const expectedLocalModule = 'file:../../locals/../../mymodule';
       const expectedCompositePackageJSON = {
         name: 'test-service',
         version: '1.0.0',
@@ -274,14 +278,52 @@ describe('packExternalModules', () => {
         dependencies: {
           '@scoped/vendor': '1.0.0',
           uuid: '^5.4.1',
-          localmodule: 'file:../../locals/../../mymodule',
+          localmodule: expectedLocalModule,
           bluebird: '^3.4.0'
+        }
+      };
+
+      const fakePackageLockJSON = {
+        name: 'test-service',
+        version: '1.0.0',
+        description: 'Packaged externals for test-service',
+        private: true,
+        dependencies: {
+          '@scoped/vendor': '1.0.0',
+          uuid: {
+            version: '^5.4.1'
+          },
+          bluebird: {
+            version: '^3.4.0'
+          },
+          localmodule: {
+            version: 'file:../../mymodule'
+          }
+        }
+      };
+      const expectedPackageLockJSON = {
+        name: 'test-service',
+        version: '1.0.0',
+        description: 'Packaged externals for test-service',
+        private: true,
+        dependencies: {
+          '@scoped/vendor': '1.0.0',
+          uuid: {
+            version: '^5.4.1'
+          },
+          bluebird: {
+            version: '^3.4.0'
+          },
+          localmodule: {
+            version: expectedLocalModule
+          }
         }
       };
 
       _.set(serverless, 'service.custom.webpackIncludeModules.packagePath', path.join('locals', 'package.json'));
       module.webpackOutputPath = 'outputPath';
-      fsExtraMock.pathExists.yields(null, false);
+      readFileSyncStub.returns(fakePackageLockJSON);
+      fsExtraMock.pathExists.yields(null, true);
       fsExtraMock.copy.yields();
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
@@ -294,9 +336,10 @@ describe('packExternalModules', () => {
       return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
         // The module package JSON and the composite one should have been stored
-        expect(writeFileSyncStub).to.have.been.calledTwice,
+        expect(writeFileSyncStub).to.have.been.calledThrice,
         expect(writeFileSyncStub.firstCall.args[1]).to.equal(JSON.stringify(expectedCompositePackageJSON, null, 2)),
-        expect(writeFileSyncStub.secondCall.args[1]).to.equal(JSON.stringify(expectedPackageJSON, null, 2)),
+        expect(writeFileSyncStub.secondCall.args[1]).to.equal(JSON.stringify(expectedPackageLockJSON, null, 2)),
+        expect(writeFileSyncStub.thirdCall.args[1]).to.equal(JSON.stringify(expectedPackageJSON, null, 2)),
         // The modules should have been copied
         expect(fsExtraMock.copy).to.have.been.calledOnce,
         // npm ls and npm prune should have been called
@@ -702,10 +745,7 @@ describe('packExternalModules', () => {
         expect(writeFileSyncStub.firstCall.args[1]).to.equal(JSON.stringify(expectedCompositePackageJSON, null, 2)),
         expect(writeFileSyncStub.secondCall.args[1]).to.equal(JSON.stringify(expectedPackageJSON, null, 2)),
         // The modules should have been copied
-        expect(fsExtraMock.copy).to.have.been.calledTwice,
-        expect(fsExtraMock.copy.firstCall).to.have.been.calledWith(
-          sinon.match(/package-lock.json$/)
-        ),
+        expect(fsExtraMock.copy).to.have.been.calledOnce,
         // npm ls and npm prune should have been called
         expect(childProcessMock.exec).to.have.been.calledThrice,
         expect(childProcessMock.exec.firstCall).to.have.been.calledWith(
@@ -741,9 +781,9 @@ describe('packExternalModules', () => {
       };
 
       module.webpackOutputPath = 'outputPath';
+      readFileSyncStub.throws(new Error('Failed to read package-lock.json'));
       fsExtraMock.pathExists.yields(null, true);
-      fsExtraMock.copy.onFirstCall().yields(new Error('Failed to read package-lock.json'));
-      fsExtraMock.copy.onSecondCall().yields();
+      fsExtraMock.copy.onFirstCall().yields();
       childProcessMock.exec.onFirstCall().yields(null, '{}', '');
       childProcessMock.exec.onSecondCall().yields(null, '', '');
       childProcessMock.exec.onThirdCall().yields();
@@ -755,10 +795,7 @@ describe('packExternalModules', () => {
         expect(writeFileSyncStub.firstCall.args[1]).to.equal(JSON.stringify(expectedCompositePackageJSON, null, 2)),
         expect(writeFileSyncStub.secondCall.args[1]).to.equal(JSON.stringify(expectedPackageJSON, null, 2)),
         // The modules should have been copied
-        expect(fsExtraMock.copy).to.have.been.calledTwice,
-        expect(fsExtraMock.copy.firstCall).to.have.been.calledWith(
-          sinon.match(/package-lock.json$/)
-        ),
+        expect(fsExtraMock.copy).to.have.been.calledOnce,
         // npm ls and npm prune should have been called
         expect(childProcessMock.exec).to.have.been.calledThrice,
         expect(childProcessMock.exec.firstCall).to.have.been.calledWith(


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #263 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Local module reference paths are now rebased to the package directories where the package.json is, that is used to install the dependency. This will let npm find the local module (what was the actual error) and package it correctly.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Use a `file:` reference in the dependencies and do a `serverless package`. The command should succeed and the local module should exist in the packaged ZIP's node_modules folder.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
