### PR TITLE
Set target to 'node' if not specified by the configuration.

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -59,7 +59,7 @@ module.exports = {
 
     const getEntryForFunction = (name, serverlessFunction) => {
       const handler = serverlessFunction.handler;
-      
+
       const handlerFile = getHandlerFile(handler);
       if (!handlerFile) {
         _.get(this.serverless, 'service.provider.name') !== 'google' &&
@@ -117,6 +117,11 @@ module.exports = {
     // Default context
     if (!this.webpackConfig.context) {
       this.webpackConfig.context = this.serverless.config.servicePath;
+    }
+
+    // Default target
+    if (!this.webpackConfig.target) {
+      this.webpackConfig.target = 'node';
     }
 
     // Default output

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -122,6 +122,35 @@ describe('validate', () => {
       .then(() => expect(module.webpackConfig.context).to.equal(testServicePath));
   });
 
+  describe('default target', () => {
+    it('should set a default `webpackConfig.target` if not present', () => {
+      const testConfig = {
+        entry: 'test',
+        output: {},
+      };
+      const testServicePath = 'testpath';
+      module.serverless.config.servicePath = testServicePath;
+      module.serverless.service.custom.webpack = testConfig;
+      return module
+      .validate()
+      .then(() => expect(module.webpackConfig.target).to.equal('node'));
+    });
+
+    it('should not change `webpackConfig.target` if one is present', () => {
+      const testConfig = {
+        entry: 'test',
+        target: 'myTarget',
+        output: {},
+      };
+      const testServicePath = 'testpath';
+      module.serverless.config.servicePath = testServicePath;
+      module.serverless.service.custom.webpack = testConfig;
+      return module
+      .validate()
+      .then(() => expect(module.webpackConfig.target).to.equal('myTarget'));
+    });
+  });
+
   describe('default output', () => {
     it('should set a default `webpackConfig.output` if not present', () => {
       const testEntry = 'testentry';


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #276 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Trivial change: Set target to 'node' in case it is not set in the configuration.
Added unit tests.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Supply a webpack configuration without the target property. It should be set to 'node' automatically and a Serverless service should deploy and run correctly (especially the environment variables which break if the target is not set in the webpack compiler).

## Todos:

- [x] Write tests
- ~~[ ] Write documentation~~ not relevant
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
