### PR TITLE
enable webpackIncludeModules for webpack-no-watch

### DIFF
--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -9,7 +9,9 @@ module.exports = {
     if (this.options['webpack-no-watch']) {
       // If we do not watch we will just run an ordinary compile
       this.serverless.cli.log('Watch disabled by option.');
-      return this.serverless.pluginManager.spawn('webpack:compile');
+      return BbPromise.bind(this)
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+        .then(this.packExternalModules);
     }
 
     this.serverless.cli.log('Bundling with Webpack...');


### PR DESCRIPTION
I got this for webpack-no-watch, not sure how to do this for the watch mode.