### PR TITLE
Fix npm file references package lock

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -23,7 +23,7 @@ function rebasePackageLock(pathToPackageRoot, module) {
 
   if (module.dependencies) {
     _.forIn(module.dependencies, moduleDependency => {
-      rebasePackageLock(moduleDependency);
+      rebasePackageLock(pathToPackageRoot, moduleDependency);
     });
   }
 }

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -286,7 +286,7 @@ module.exports = {
              * We should not be modifying 'package-lock.json'
              * because this file should be treat as internal to npm.
              * 
-             * Rebase package is a temporary workaround and must be
+             * Rebase package-lock is a temporary workaround and must be
              * removed as soon as https://github.com/npm/npm/issues/19183 gets fixed.
              */
             rebasePackageLock(relPath, packageLockJson);

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -7,6 +7,27 @@ const childProcess = require('child_process');
 const fse = require('fs-extra');
 const isBuiltinModule = require('is-builtin-module');
 
+function rebaseFileReferences(pathToPackageRoot, moduleVersion) {
+  if (/^file:[^/]{2}/.test(moduleVersion)) {
+    const filePath = _.replace(moduleVersion, /^file:/, '');
+    return _.replace(`file:${pathToPackageRoot}/${filePath}`, /\\/g, '/');
+  }
+
+  return moduleVersion;
+}
+
+function rebasePackageLock(pathToPackageRoot, module) {
+  if (module.version) {
+    module.version = rebaseFileReferences(pathToPackageRoot, module.version);
+  }
+
+  if (module.dependencies) {
+    _.forIn(module.dependencies, moduleDependency => {
+      rebasePackageLock(moduleDependency);
+    });
+  }
+}
+
 /**
  * Add the given modules to a package json's dependencies.
  */
@@ -20,10 +41,7 @@ function addModulesToPackageJson(externalModules, packageJson, pathToPackageRoot
     }
     let moduleVersion = _.join(_.tail(splitModule), '@');
     // We have to rebase file references to the target package.json
-    if (/^file:[^/]{2}/.test(moduleVersion)) {
-      const filePath = _.replace(moduleVersion, /^file:/, '');
-      moduleVersion = _.replace(`file:${pathToPackageRoot}/${filePath}`, /\\/g, '/');
-    }
+    moduleVersion = rebaseFileReferences(pathToPackageRoot, moduleVersion);
     packageJson.dependencies = packageJson.dependencies || {};
     packageJson.dependencies[_.first(splitModule)] = moduleVersion;
   });
@@ -262,8 +280,21 @@ module.exports = {
       .then(exists => {
         if (exists) {
           this.serverless.cli.log('Package lock found - Using locked versions');
-          return BbPromise.fromCallback(cb => fse.copy(packageLockPath, path.join(compositeModulePath, 'package-lock.json'), cb))
-          .catch(err => this.serverless.cli.log(`Warning: Could not copy lock file: ${err.message}`));
+          try {
+            const packageLockJson = this.serverless.utils.readFileSync(packageLockPath);
+            /**
+             * We should not be modifying 'package-lock.json'
+             * because this file should be treat as internal to npm.
+             * 
+             * Rebase package is a temporary workaround and must be
+             * removed as soon as https://github.com/npm/npm/issues/19183 gets fixed.
+             */
+            rebasePackageLock(relPath, packageLockJson);
+
+            this.serverless.utils.writeFileSync(path.join(compositeModulePath, 'package-lock.json'), JSON.stringify(packageLockJson, null, 2));
+          } catch(err) {
+            this.serverless.cli.log(`Warning: Could not read lock file: ${err.message}`);
+          }
         }
         return BbPromise.resolve();
       })


### PR DESCRIPTION
Complementing https://github.com/serverless-heaven/serverless-webpack/pull/281 as discussed in https://github.com/serverless-heaven/serverless-webpack/pull/281#issuecomment-352442749.

@HyperBrain 
I ended up rewriting the `package-lock.json` file instead of replacing its content. Are you ok with this approach?