### PR TITLE
Refactor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ WebPack's [Tree-Shaking][link-webpack-tree] optimization.
 ## Recent improvements and important changes
 
 * Webpack 2 support has been dropped in favor of Webpack 4
+* Cleaned up configuration. You should now use a `custom.webpack` object to configure everything relevant for the plugin. The old configuration still works but will be removed in the next major release. For details see below.
 * This 5.0.0 prerelease is based on the current 4.4.0
 
 For the complete release notes see the end of this document.
@@ -48,12 +49,27 @@ plugins:
 
 ## Configure
 
-By default the plugin will look for a `webpack.config.js` in the service directory.
-Alternatively, you can specify a different file or configuration in `serverless.yml`:
+The configuration of the plugin is done by defining a `custom: webpack` object in your `serverless.yml` with your specific configuration. All settings are optional and will be set to reasonable defaults if missing.
+
+See the sections below for detailed descriptions of the settings. The defaults are:
 
 ```yaml
 custom:
-  webpack: ./folder/my-webpack.config.js
+  webpack:
+    webpackConfig: 'webpack.config.js'   # Name of webpack configuration file
+    webpackIncludeModules: false   # Node modules configuration for packaging
+    packager: 'npm'   # Reserved for future use. Any other values will not work right now.
+    packExternalModulesMaxBuffer: 200 * 1024   # Size of stdio buffers for spawned child processes
+```
+
+### Webpack configuration file
+
+By default the plugin will look for a `webpack.config.js` in the service directory. Alternatively, you can specify a different file or configuration in `serverless.yml`.
+
+```yaml
+custom:
+  webpack:
+    webpackConfig: ./folder/my-webpack.config.js
 ```
 
 A base Webpack configuration might look like this:
@@ -209,7 +225,8 @@ module.exports = {
 ```yaml
 # serverless.yml
 custom:
-  webpackIncludeModules: true # enable auto-packing of external modules
+  webpack:
+    webpackIncludeModules: true # enable auto-packing of external modules
 ```
 
 
@@ -223,8 +240,9 @@ use a different package file, set `packagePath` to your custom `package.json`:
 ```yaml
 # serverless.yml
 custom:
-  webpackIncludeModules:
-    packagePath: '../package.json' # relative path to custom package.json file.
+  webpack:
+    webpackIncludeModules:
+      packagePath: '../package.json' # relative path to custom package.json file.
 ```
 > Note that only relative path is supported at the moment.
 
@@ -246,10 +264,11 @@ your service's production dependencies in `package.json`.
 ```yaml
 # serverless.yml
 custom:
-  webpackIncludeModules:
-    forceInclude:
-      - module1
-      - module2
+  webpack:
+    webpackIncludeModules:
+      forceInclude:
+        - module1
+        - module2
 ```
 
 #### Forced exclusion
@@ -262,10 +281,11 @@ Just add them to the `forceExclude` array property and they will not be packaged
 ```yaml
 # serverless.yml
 custom:
-  webpackIncludeModules:
-    forceExclude:
-      - module1
-      - module2
+  webpack:
+    webpackIncludeModules:
+      forceExclude:
+        - module1
+        - module2
 ```
 
 If you specify a module in both arrays, `forceInclude` and `forceExclude`, the

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -1,0 +1,77 @@
+/**
+ * Plugin configuration.
+ */
+
+const _ = require('lodash');
+
+/** 
+ * Plugin defaults
+ */
+const DefaultConfig = {
+  webpackConfig: 'webpack.config.js',
+  webpackIncludeModules: false,
+  packager: 'npm',
+  packExternalModulesMaxBuffer: 200 * 1024,
+  config: null
+};
+
+class Configuration {
+
+  constructor(custom) {
+
+    this._config = {};
+    this._hasLegacyConfig = false;
+
+    // Set configuration from sls.service.custom. We fall back to the
+    // old configuration to keep backwards compatibility.
+    if (custom) {
+      if (custom.webpackIncludeModules) {
+        this._config.webpackIncludeModules = custom.webpackIncludeModules;
+        this._hasLegacyConfig = true;
+      }
+      if (custom.packExternalModulesMaxBuffer) {
+        this._config.packExternalModulesMaxBuffer = custom.packExternalModulesMaxBuffer;
+        this._hasLegacyConfig = true;
+      }
+      if (_.isString(custom.webpack)) {
+        this._config.webpackConfig = custom.webpack;
+        this._hasLegacyConfig = true;
+      } else {
+        _.assign(this._config, custom.webpack || {});
+      }
+    }
+
+    // Set defaults for all missing properties
+    _.defaults(this._config, DefaultConfig);
+  }
+
+  get webpackConfig() {
+    return this._config.webpackConfig;
+  }
+
+  get webpackIncludeModules() {
+    return this._config.webpackIncludeModules;
+  }
+
+  get packExternalModulesMaxBuffer() {
+    return this._config.packExternalModulesMaxBuffer;
+  }
+
+  get packager() {
+    return this._config.packager;
+  }
+
+  get config() {
+    return this._config.config;
+  }
+
+  get hasLegacyConfig() {
+    return this._hasLegacyConfig;
+  }
+
+  toJSON() {
+    return _.omitBy(this._config, _.isNil);
+  }
+}
+
+module.exports = Configuration;

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * Plugin configuration.
  */

--- a/lib/Configuration.test.js
+++ b/lib/Configuration.test.js
@@ -1,0 +1,116 @@
+'use strict';
+/**
+ * Unit tests for Configuration.
+ */
+
+const chai = require('chai');
+const Configuration = require('./Configuration');
+
+const expect = chai.expect;
+
+describe('Configuration', () => {
+  describe('defaults', () => {
+    let expectedDefaults;
+
+    before(() => {
+      expectedDefaults = {
+        webpackConfig: 'webpack.config.js',
+        webpackIncludeModules: false,
+        packager: 'npm',
+        packExternalModulesMaxBuffer: 200 * 1024,
+        config: null
+      };
+    });
+
+    it('should set default configuration without custom', () => {
+      const config = new Configuration();
+      expect(config).to.have.a.property('_config').that.deep.equals(expectedDefaults);
+      expect(config).to.have.a.property('hasLegacyConfig').that.is.false;
+    });
+
+    it('should set default configuration without webpack property', () => {
+      const config = new Configuration({});
+      expect(config).to.have.a.property('_config').that.deep.equals(expectedDefaults);
+      expect(config).to.have.a.property('hasLegacyConfig').that.is.false;
+    });
+  });
+
+  describe('with legacy configuration', () => {
+    it('should use custom.webpackIncludeModules', () => {
+      const testCustom = { webpackIncludeModules: { forceInclude: ['mod1'] } };
+      const config = new Configuration(testCustom);
+      expect(config).to.have.a.property('webpackIncludeModules').that.deep.equals(testCustom.webpackIncludeModules);
+    });
+
+    it('should use custom.packExternalModulesMaxBuffer', () => {
+      const testCustom = { packExternalModulesMaxBuffer: 4711 };
+      const config = new Configuration(testCustom);
+      expect(config).to.have.a.property('packExternalModulesMaxBuffer').that.equals(4711);
+    });
+
+    it('should use custom.webpack as string', () => {
+      const testCustom = { webpack: 'myWebpackFile.js' };
+      const config = new Configuration(testCustom);
+      expect(config).to.have.a.property('webpackConfig').that.equals('myWebpackFile.js');
+    });
+
+    it('should detect it', () => {
+      const testCustom = { webpack: 'myWebpackFile.js' };
+      const config = new Configuration(testCustom);
+      expect(config).to.have.a.property('hasLegacyConfig').that.is.true;
+    });
+
+    it('should add defaults', () => {
+      const testCustom = { 
+        webpackIncludeModules: { forceInclude: ['mod1'] },
+        webpack: 'myWebpackFile.js'
+      };
+      const config = new Configuration(testCustom);
+      expect(config).to.have.a.property('webpackIncludeModules').that.deep.equals(testCustom.webpackIncludeModules);
+      expect(config._config).to.deep.equal({
+        webpackConfig: 'myWebpackFile.js',
+        webpackIncludeModules: { forceInclude: ['mod1'] },
+        packager: 'npm',
+        packExternalModulesMaxBuffer: 200 * 1024,
+        config: null
+      });
+    });
+  });
+
+  describe('with a configuration object', () => {
+    it('should use it and add any defaults', () => {
+      const testCustom = {
+        webpack: {
+          webpackIncludeModules: { forceInclude: ['mod1'] },
+          webpackConfig: 'myWebpackFile.js'
+        }
+      };
+      const config = new Configuration(testCustom);
+      expect(config._config).to.deep.equal({
+        webpackConfig: 'myWebpackFile.js',
+        webpackIncludeModules: { forceInclude: ['mod1'] },
+        packager: 'npm',
+        packExternalModulesMaxBuffer: 200 * 1024,
+        config: null
+      });
+    });
+
+    it('should favor new configuration', () => {
+      const testCustom = {
+        webpackIncludeModules: { forceExclude: ['mod2'] },
+        webpack: {
+          webpackIncludeModules: { forceInclude: ['mod1'] },
+          webpackConfig: 'myWebpackFile.js'
+        }
+      };
+      const config = new Configuration(testCustom);
+      expect(config._config).to.deep.equal({
+        webpackConfig: 'myWebpackFile.js',
+        webpackIncludeModules: { forceInclude: ['mod1'] },
+        packager: 'npm',
+        packExternalModulesMaxBuffer: 200 * 1024,
+        config: null
+      });
+    });
+  });
+});

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -174,10 +174,7 @@ module.exports = {
 
     const stats = this.compileStats;
 
-    const includes = (
-      this.serverless.service.custom &&
-      this.serverless.service.custom.webpackIncludeModules
-    );
+    const includes = this.configuration.webpackIncludeModules;
 
     if (!includes) {
       return BbPromise.resolve();
@@ -194,7 +191,7 @@ module.exports = {
     .then(packager => {
       // Get first level dependency graph
       this.options.verbose && this.serverless.cli.log(`Fetch dependency graph from ${packageJsonPath}`);
-      const maxExecBufferSize = this.serverless.service.custom.packExternalModulesMaxBuffer || 200 * 1024;
+      const maxExecBufferSize = this.configuration.packExternalModulesMaxBuffer;
 
       return packager.getProdDependencies(path.dirname(packageJsonPath), 1, maxExecBufferSize)
       .then(dependencyGraph => {

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -190,7 +190,7 @@ module.exports = {
     const packageJsonPath = path.join(process.cwd(), packagePath);
 
     // Determine and create packager
-    return BbPromise.try(() => Packagers.get.call(this, 'npm'))
+    return BbPromise.try(() => Packagers.get.call(this, this.configuration.packager))
     .then(packager => {
       // Get first level dependency graph
       this.options.verbose && this.serverless.cli.log(`Fetch dependency graph from ${packageJsonPath}`);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -6,6 +6,7 @@ const fse = require('fs-extra');
 const glob = require('glob');
 const lib = require('./index');
 const _ = require('lodash');
+const Configuration = require('./Configuration');
 
 /**
  * For automatic entry detection we sort the found files to solve ambiguities.
@@ -74,11 +75,14 @@ module.exports = {
       };
     };
 
-    this.webpackConfig = (
-      this.serverless.service.custom &&
-      this.serverless.service.custom.webpack ||
-      'webpack.config.js'
-    );
+    // Initialize plugin configuration
+    this.configuration = new Configuration(this.serverless.service.custom);
+    this.options.verbose && this.serverless.cli.log(`Using configuration:\n${JSON.stringify(this.configuration, null, 2)}`);
+    if (this.configuration.hasLegacyConfig) {
+      this.serverless.cli.log('Legacy configuration detected. Consider to use "custom.webpack" as object (see README).');
+    }
+
+    this.webpackConfig = this.configuration.config || this.configuration.webpackConfig;
 
     // Expose entries - must be done before requiring the webpack configuration
     const entries = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -278,9 +278,9 @@
         "apollo-link-core": "0.5.4",
         "graphql": "0.10.5",
         "graphql-anywhere": "3.1.0",
-        "graphql-tag": "2.5.0",
+        "graphql-tag": "2.8.0",
         "redux": "3.7.2",
-        "symbol-observable": "1.0.4",
+        "symbol-observable": "1.2.0",
         "whatwg-fetch": "2.0.3"
       }
     },
@@ -291,7 +291,7 @@
       "dev": true,
       "requires": {
         "graphql": "0.10.5",
-        "graphql-tag": "2.5.0",
+        "graphql-tag": "2.8.0",
         "zen-observable-ts": "0.4.4"
       }
     },
@@ -403,13 +403,12 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.155.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.155.0.tgz",
-      "integrity": "sha1-KuU4H5fo9C5lDh0lmZ6QkKk20MY=",
+      "version": "2.205.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.205.0.tgz",
+      "integrity": "sha1-GpNzAlPivgJ6S9OvkkjL2gVz3oA=",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
-        "crypto-browserify": "1.0.9",
         "events": "1.1.1",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
@@ -504,9 +503,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -542,9 +541,9 @@
       }
     },
     "boxen": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
-      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
@@ -553,7 +552,7 @@
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
-        "widest-line": "1.0.0"
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -610,7 +609,7 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
+        "base64-js": "1.2.3",
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
@@ -783,9 +782,9 @@
       }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
       "requires": {
         "graceful-readlink": "1.0.1"
@@ -842,7 +841,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.2.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -938,12 +937,6 @@
         }
       }
     },
-    "crypto-browserify": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
-      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA=",
-      "dev": true
-    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -979,7 +972,7 @@
         "decompress-targz": "4.1.1",
         "decompress-unzip": "4.0.1",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.2.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
       }
@@ -1673,9 +1666,9 @@
       }
     },
     "filesize": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.0.tgz",
+      "integrity": "sha512-g5OWtoZWcPI56js1DFhIEqyG9tnu/7sG3foHwgS9KGYFMfsYguI3E+PRVCmtmE96VajQIEMRU2OhN+ME589Gdw==",
       "dev": true
     },
     "find-up": {
@@ -1871,9 +1864,9 @@
       "dev": true
     },
     "graphlib": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.1.tgz",
-      "integrity": "sha1-QjUsUrovTQNctWbrkfc5X3bryVE=",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "dev": true,
       "requires": {
         "lodash": "4.17.5"
@@ -1885,7 +1878,7 @@
       "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
       "dev": true,
       "requires": {
-        "iterall": "1.1.3"
+        "iterall": "1.2.2"
       }
     },
     "graphql-anywhere": {
@@ -1895,9 +1888,9 @@
       "dev": true
     },
     "graphql-tag": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.5.0.tgz",
-      "integrity": "sha1-tDv9i1urzSwgWtaAwD6YsjiTTg8=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.8.0.tgz",
+      "integrity": "sha1-Us3qB6hCFU7BGi6EDBG5d/m4Nc4=",
       "dev": true
     },
     "growl": {
@@ -1946,9 +1939,9 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-symbol-support-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
-      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
       "dev": true
     },
     "has-to-string-tag-x": {
@@ -1957,7 +1950,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-unicode": {
@@ -2293,9 +2286,9 @@
       }
     },
     "iterall": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
       "dev": true
     },
     "jmespath": {
@@ -2341,19 +2334,33 @@
       "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
       "dev": true
     },
+    "json-cycle": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-cycle/-/json-cycle-1.3.0.tgz",
+      "integrity": "sha512-FD/SedD78LCdSvJaOUQAXseT8oQBb5z6IVYaQaCrVUlu9zOAr1BDdKyVYQaSD/GDsAMrXpKcOyBD4LIl8nfjHw==",
+      "dev": true
+    },
     "json-refs": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
       "integrity": "sha1-uesB/in16j6Sh48VrqEK04taz4k=",
       "dev": true,
       "requires": {
-        "commander": "2.9.0",
-        "graphlib": "2.1.1",
+        "commander": "2.14.1",
+        "graphlib": "2.1.5",
         "js-yaml": "3.10.0",
         "native-promise-only": "0.8.1",
         "path-loader": "1.0.4",
         "slash": "1.0.0",
         "uri-js": "3.0.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "dev": true
+        }
       }
     },
     "json-schema": {
@@ -2490,9 +2497,9 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
+      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
       "dev": true
     },
     "lodash.difference": {
@@ -2575,9 +2582,9 @@
       "dev": true
     },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "dev": true,
       "requires": {
         "pify": "3.0.0"
@@ -2603,9 +2610,9 @@
       "dev": true
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -2714,9 +2721,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
       "dev": true
     },
     "ms": {
@@ -2767,9 +2774,9 @@
       }
     },
     "node-forge": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.3.tgz",
+      "integrity": "sha512-UGP1kI3GWGcvOgODS7o1YodpkE9RzJHMv1nlSH35iBjPZM/702cWZ1Z2wFBGYkgvzG0vfMp7scs9+gKjHQ3DlA==",
       "dev": true
     },
     "normalize-package-data": {
@@ -4442,6 +4449,12 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.2.0.tgz",
+      "integrity": "sha512-smRWXzkvxw72VquyZ0wggySl7PFUtoDhvhpdwgESXxUrH7vVhhp9asfup1+rVLrhsl7L45Ee1Q/l5R2Ul4MwUg==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4457,9 +4470,9 @@
       "dev": true
     },
     "opn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-      "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
+      "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
       "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
@@ -4528,7 +4541,7 @@
       "dev": true,
       "requires": {
         "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
+        "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
         "semver": "5.5.0"
       }
@@ -4575,7 +4588,7 @@
       "dev": true,
       "requires": {
         "native-promise-only": "0.8.1",
-        "superagent": "3.8.1"
+        "superagent": "3.8.2"
       }
     },
     "path-parse": {
@@ -4687,6 +4700,12 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
+    "promise-queue": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
+      "integrity": "sha1-L29ffA9tCBCelnZZx5uIqe1ek7Q=",
+      "dev": true
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -4751,9 +4770,9 @@
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -4815,18 +4834,18 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.5",
-        "lodash-es": "4.17.4",
+        "lodash-es": "4.17.5",
         "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.2.0"
       }
     },
     "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.2",
+        "rc": "1.2.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -4836,7 +4855,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2"
+        "rc": "1.2.5"
       }
     },
     "remove-trailing-separator": {
@@ -5007,17 +5026,6 @@
       "dev": true,
       "requires": {
         "commander": "2.8.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        }
       }
     },
     "semver": {
@@ -5041,44 +5049,47 @@
       "dev": true
     },
     "serverless": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.24.1.tgz",
-      "integrity": "sha1-3QkqGG1ATcnkgVHR98wt99JwNVo=",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.26.1.tgz",
+      "integrity": "sha1-IAN7KM42qzgdNpKQgfNrJJ0SZUI=",
       "dev": true,
       "requires": {
         "@serverless/fdk": "0.5.1",
         "apollo-client": "1.9.3",
         "archiver": "1.3.0",
         "async": "1.5.2",
-        "aws-sdk": "2.155.0",
+        "aws-sdk": "2.205.0",
         "bluebird": "3.5.1",
         "chalk": "2.0.1",
         "ci-info": "1.1.2",
         "download": "5.0.3",
-        "filesize": "3.5.11",
+        "fast-levenshtein": "2.0.6",
+        "filesize": "3.6.0",
         "fs-extra": "0.26.7",
         "get-stdin": "5.0.1",
         "globby": "6.1.0",
         "graceful-fs": "4.1.11",
         "graphql": "0.10.5",
-        "graphql-tag": "2.5.0",
+        "graphql-tag": "2.8.0",
         "https-proxy-agent": "1.0.0",
         "is-docker": "1.1.0",
         "js-yaml": "3.10.0",
+        "json-cycle": "1.3.0",
         "json-refs": "2.1.7",
         "jwt-decode": "2.2.0",
         "lodash": "4.17.5",
         "minimist": "1.2.0",
-        "moment": "2.19.2",
+        "moment": "2.21.0",
         "node-fetch": "1.7.3",
-        "node-forge": "0.7.1",
-        "opn": "5.1.0",
+        "node-forge": "0.7.3",
+        "object-hash": "1.2.0",
+        "opn": "5.2.0",
+        "promise-queue": "2.2.5",
         "raven": "1.2.1",
-        "rc": "1.2.2",
+        "rc": "1.2.5",
         "replaceall": "0.1.6",
         "semver": "5.5.0",
         "semver-regex": "1.0.0",
-        "shelljs": "0.6.1",
         "tabtab": "2.2.2",
         "update-notifier": "2.3.0",
         "uuid": "2.0.3",
@@ -5151,12 +5162,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "shelljs": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },
     "signal-exit": {
@@ -5393,9 +5398,9 @@
       }
     },
     "superagent": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
-      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -5405,7 +5410,7 @@
         "form-data": "2.3.1",
         "formidable": "1.1.1",
         "methods": "1.1.2",
-        "mime": "1.4.1",
+        "mime": "1.6.0",
         "qs": "6.5.1",
         "readable-stream": "2.3.3"
       },
@@ -5430,9 +5435,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
     },
     "table": {
@@ -5742,7 +5747,7 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.2.2",
+        "boxen": "1.3.0",
         "chalk": "2.0.1",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
@@ -5872,12 +5877,45 @@
       }
     },
     "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
     "eslint": "node node_modules/eslint/bin/eslint.js --ext .js lib"
   },
   "nyc": {
+    "all": true,
     "exclude": [
       "tests/**/*.*",
-      "**/*.test.js"
+      "**/*.test.js",
+      "coverage/**",
+      "examples/**"
     ],
     "reporter": [
       "lcov",
@@ -61,7 +64,7 @@
     "mocha": "^5.0.2",
     "mockery": "^2.1.0",
     "nyc": "^11.4.1",
-    "serverless": "^1.24.1",
+    "serverless": "^1.26.1",
     "sinon": "^4.4.2",
     "sinon-chai": "^3.0.0"
   },

--- a/tests/packExternalModules.test.js
+++ b/tests/packExternalModules.test.js
@@ -7,6 +7,7 @@ const chai = require('chai');
 const sinon = require('sinon');
 const mockery = require('mockery');
 const Serverless = require('serverless');
+const Configuration = require('../lib/Configuration');
 
 // Mocks
 const fsExtraMockFactory = require('./mocks/fs-extra.mock');
@@ -101,6 +102,11 @@ describe('packExternalModules', () => {
       options: {
         verbose: true
       },
+      configuration: new Configuration({ 
+        webpack: {
+          webpackIncludeModules: true
+        } 
+      })
     }, baseModule);
   });
 
@@ -225,7 +231,7 @@ describe('packExternalModules', () => {
     };
 
     it('should do nothing if webpackIncludeModules is not set', () => {
-      _.unset(serverless, 'service.custom.webpackIncludeModules');
+      module.configuration = new Configuration();
       module.compileStats = { stats: [] };
       return expect(module.packExternalModules()).to.be.fulfilled
       .then(() => BbPromise.all([
@@ -319,7 +325,13 @@ describe('packExternalModules', () => {
         }
       };
 
-      _.set(serverless, 'service.custom.webpackIncludeModules.packagePath', path.join('locals', 'package.json'));
+      module.configuration = new Configuration({
+        webpack: {
+          webpackIncludeModules: {
+            packagePath: path.join('locals', 'package.json')
+          }
+        }
+      });
       module.webpackOutputPath = 'outputPath';
       readFileSyncStub.returns(fakePackageLockJSON);
       fsExtraMock.pathExists.yields(null, true);
@@ -494,11 +506,13 @@ describe('packExternalModules', () => {
           pg: '^4.3.5'
         }
       };
-      serverless.service.custom = {
-        webpackIncludeModules: {
-          forceInclude: ['pg']
+      module.configuration = new Configuration({
+        webpack: {
+          webpackIncludeModules: {
+            forceInclude: ['pg']
+          }
         }
-      };
+      });
       module.webpackOutputPath = 'outputPath';
       fsExtraMock.pathExists.yields(null, false);
       fsExtraMock.copy.yields();
@@ -542,11 +556,13 @@ describe('packExternalModules', () => {
           'not-in-prod-deps': ''
         }
       };
-      serverless.service.custom = {
-        webpackIncludeModules: {
-          forceInclude: ['not-in-prod-deps']
+      module.configuration = new Configuration({
+        webpack: {
+          webpackIncludeModules: {
+            forceInclude: ['not-in-prod-deps']
+          }
         }
-      };
+      });
       module.webpackOutputPath = 'outputPath';
       fsExtraMock.pathExists.yields(null, false);
       fsExtraMock.copy.yields();
@@ -588,12 +604,14 @@ describe('packExternalModules', () => {
           pg: '^4.3.5'
         }
       };
-      serverless.service.custom = {
-        webpackIncludeModules: {
-          forceInclude: ['pg'],
-          forceExclude: ['uuid']
+      module.configuration = new Configuration({
+        webpack: {
+          webpackIncludeModules: {
+            forceInclude: ['pg'],
+            forceExclude: ['uuid']
+          }
         }
-      };
+      });
       module.webpackOutputPath = 'outputPath';
       fsExtraMock.pathExists.yields(null, false);
       fsExtraMock.copy.yields();

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -8,6 +8,7 @@ const path = require('path');
 const Serverless = require('serverless');
 const fsExtraMockFactory = require('./mocks/fs-extra.mock');
 
+chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
 
 const expect = chai.expect;
@@ -67,7 +68,7 @@ describe('validate', () => {
         path: 'test',
       },
     };
-    module.serverless.service.custom.webpack = testConfig;
+    _.set(module.serverless.service, 'custom.webpack.config', testConfig);
     return module
       .validate()
       .then(() => expect(module.webpackConfig).to.eql(testConfig));
@@ -82,7 +83,7 @@ describe('validate', () => {
         path: testOutPath,
       },
     };
-    module.serverless.service.custom.webpack = testConfig;
+    _.set(module.serverless.service, 'custom.webpack.config', testConfig);
     return module
       .validate()
       .then(() => expect(fsExtraMock.removeSync).to.have.been.calledWith(testOutPath));
@@ -98,7 +99,7 @@ describe('validate', () => {
       },
     };
     _.set(module, 'keepOutputDirectory', true);
-    module.serverless.service.custom.webpack = testConfig;
+    _.set(module.serverless.service, 'custom.webpack.config', testConfig);
     return module
       .validate()
       .then(() => expect(fsExtraMock.removeSync).to.not.have.been.called);
@@ -117,7 +118,7 @@ describe('validate', () => {
     const testOptionsOut = 'testdir';
     module.options.out = testOptionsOut;
     module.serverless.config.servicePath = testServicePath;
-    module.serverless.service.custom.webpack = testConfig;
+    _.set(module.serverless.service, 'custom.webpack.config', testConfig);
     return module
       .validate()
       .then(() => expect(module.webpackConfig.output).to.eql({
@@ -133,7 +134,7 @@ describe('validate', () => {
     };
     const testServicePath = 'testpath';
     module.serverless.config.servicePath = testServicePath;
-    module.serverless.service.custom.webpack = testConfig;
+    _.set(module.serverless.service, 'custom.webpack.config', testConfig);
     return module
       .validate()
       .then(() => expect(module.webpackConfig.context).to.equal(testServicePath));
@@ -147,7 +148,7 @@ describe('validate', () => {
       };
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
-      module.serverless.service.custom.webpack = testConfig;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
       return module
       .validate()
       .then(() => expect(module.webpackConfig.target).to.equal('node'));
@@ -161,7 +162,7 @@ describe('validate', () => {
       };
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
-      module.serverless.service.custom.webpack = testConfig;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
       return module
       .validate()
       .then(() => expect(module.webpackConfig.target).to.equal('myTarget'));
@@ -176,7 +177,7 @@ describe('validate', () => {
       };
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
-      module.serverless.service.custom.webpack = testConfig;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
       return module
         .validate()
         .then(() => expect(module.webpackConfig.output).to.eql({
@@ -193,7 +194,7 @@ describe('validate', () => {
       };
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
-      module.serverless.service.custom.webpack = testConfig;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
       return module
         .validate()
         .then(() => expect(module.webpackConfig.output).to.eql({
@@ -207,7 +208,7 @@ describe('validate', () => {
       const testConfig = {};
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
-      module.serverless.service.custom.webpack = testConfig;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
       return module
         .validate()
         .then(() => expect(module.webpackConfig.output).to.eql({
@@ -290,7 +291,7 @@ describe('validate', () => {
           path: testOutPath,
         },
       };
-      module.serverless.service.custom.webpack = testConfig;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
       return expect(module.validate()).to.be.fulfilled
       .then(() => {
         const lib = require('../lib/index');
@@ -316,7 +317,7 @@ describe('validate', () => {
         serverless,
         options: _.cloneDeep(testOptions),
       }, baseModule);
-      configuredModule.serverless.service.custom.webpack = testConfig;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
       return expect(configuredModule.validate()).to.be.fulfilled
       .then(() => {
         const lib = require('../lib/index');
@@ -394,7 +395,7 @@ describe('validate', () => {
             path: testOutPath,
           },
         };
-        module.serverless.service.custom.webpack = testConfig;
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
         module.serverless.service.functions = testFunctionsConfig;
         globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
         return expect(module.validate()).to.be.fulfilled
@@ -424,7 +425,7 @@ describe('validate', () => {
             path: testOutPath,
           },
         };
-        module.serverless.service.custom.webpack = testConfig;
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
         module.serverless.service.functions = testFunctionsConfig;
         module.options.function = testFunction;
         globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
@@ -463,7 +464,7 @@ describe('validate', () => {
               filename: 'index.js'
             },
           };
-          module.serverless.service.custom.webpack = testConfig;
+          _.set(module.serverless.service, 'custom.webpack.config', testConfig);
           module.serverless.service.functions = testFunctionsGoogleConfig;
           module.options.function = testFunction;
           globSyncStub.returns([]);
@@ -495,7 +496,7 @@ describe('validate', () => {
         });
 
         it('should enable multiCompile', () => {
-          module.serverless.service.custom.webpack = testConfig;
+          _.set(module.serverless.service, 'custom.webpack.config', testConfig);
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
 
@@ -509,12 +510,12 @@ describe('validate', () => {
         });
 
         it('should fail if webpackConfig.entry is customised', () => {
-          module.serverless.service.custom.webpack = _.merge({}, testConfig, {
+          _.set(module.serverless.service, 'custom.webpack.config', _.merge({}, testConfig, {
             entry: {
               module1: './module1.js',
               module2: './module2.js'
             }
-          });
+          }));
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
           return expect(module.validate()).to.be.rejectedWith(
@@ -523,16 +524,16 @@ describe('validate', () => {
 
         it('should not fail if webpackConfig.entry is set to lib.entries for backward compatibility', () => {
           const lib = require('../lib/index');
-          module.serverless.service.custom.webpack = _.merge({}, testConfig, {
+          _.set(module.serverless.service, 'custom.webpack.config', _.merge({}, testConfig, {
             entry: lib.entries
-          });
+          }));
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
           return expect(module.validate()).to.be.fulfilled;
         });
 
         it('should expose all functions details in entryFunctions property', () => {
-          module.serverless.service.custom.webpack = testConfig;
+          _.set(module.serverless.service, 'custom.webpack.config', testConfig);
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
           return expect(module.validate()).to.be.fulfilled
@@ -568,7 +569,7 @@ describe('validate', () => {
         });
 
         it('should set webpackConfig output path for every functions', () => {
-          module.serverless.service.custom.webpack = testConfig;
+          _.set(module.serverless.service, 'custom.webpack.config', testConfig);
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
           return expect(module.validate()).to.be.fulfilled
@@ -584,13 +585,13 @@ describe('validate', () => {
         });
 
         it('should clone other webpackConfig options without modification', () => {
-          module.serverless.service.custom.webpack = _.merge({}, testConfig, {
+          _.set(module.serverless.service, 'custom.webpack.config', _.merge({}, testConfig, {
             devtool: 'source-map',
             context: 'some context',
             output: {
               libraryTarget: 'commonjs'
             }
-          });
+          }));
           module.serverless.service.functions = testFunctionsConfig;
           globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
           return expect(module.validate()).to.be.fulfilled
@@ -623,7 +624,7 @@ describe('validate', () => {
             path: testOutPath,
           },
         };
-        module.serverless.service.custom.webpack = testConfig;
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
         module.serverless.service.functions = testFunctionsConfig;
         module.options.function = testFunction;
         globSyncStub.returns([ 'module1.ts', 'module1.js' ]);
@@ -654,7 +655,7 @@ describe('validate', () => {
             path: testOutPath,
           },
         };
-        module.serverless.service.custom.webpack = testConfig;
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
         module.serverless.service.functions = testFunctionsConfig;
         module.options.function = testFunction;
         globSyncStub.returns([ 'module1.doc', 'module1.json', 'module1.test.js', 'module1.ts', 'module1.js' ]);
@@ -685,7 +686,7 @@ describe('validate', () => {
             path: testOutPath,
           },
         };
-        module.serverless.service.custom.webpack = testConfig;
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
         module.serverless.service.functions = testFunctionsConfig;
         module.options.function = testFunction;
         globSyncStub.returns([]);
@@ -704,7 +705,7 @@ describe('validate', () => {
             path: testOutPath,
           },
         };
-        module.serverless.service.custom.webpack = testConfig;
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
         module.serverless.service.functions = testFunctionsConfig;
         module.options.function = testFunction;
         expect(() => {
@@ -723,7 +724,7 @@ describe('validate', () => {
             path: testOutPath,
           },
         };
-        module.serverless.service.custom.webpack = testConfig;
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
         return expect(module.validate()).to.be.fulfilled
         .then(() => {
           const lib = require('../lib/index');


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

This PR consolidates all webpack plugin configuration settings into the new `custom.webpack` object. It effectively reduces cluttering of the serverless configuration and keeps all settings in one place.

There is one breaking change with the configuration: If you have chosen to embed the webpack configuration into the serverless.yml (previously by defining `custom.webpack` as an object with the contents of a webpack config file) you have to move that to `custom.webpack.config`. In my opinion this way to configure webpack is very rare and mainly used as convenience method for the unit tests, as it does not allow for dynamic entry point resolution. This feature will be dropped in the future.

The new configuration object has the following layout. If a property is omitted, it will default to the shown values:
```yaml
custom:
  webpack:
    webpackConfig: 'webpack.config.js'
    webpackIncludeModules: false
    packager: 'npm'
    packExternalModulesMaxBuffer: 200 * 1024
}
```
All settings have just been moved, but semantically are exactly as before.

However, **the old configuration keys continue to work**, but will lead to a warning message to let people know that there is a better alternative for configuration now.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Use a new class to keep the configuration centralized. The class is initialized with the serverless custom object and will populate the settings from there (using the old semantics as fallback) and it will set reasonable defaults for anything that has not been set.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

(1) Use an existing project as is. It should build as usual but show a warning.
(2) Adapt the configuration to use the new custom.webpack object. It should build as before.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- Make sure code coverage hasn't dropped **N/A**
   This PR introduced an expected drop in coverage, because it enables counting _all_ files for coverage calculation. Previously only the tested ones were counted, but it was not obvious that there were untested files in the project.
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES (most likely not noticable)
