### PR TITLE
Add --no-build switch for invoke local to use already compiled output

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,19 @@ All options that are supported by invoke local can be used as usual:
 
 > :exclamation: The old `webpack invoke` command has been disabled.
 
+#### Run a function with an existing compiled output (--no-build)
+
+On CI systems it is likely that you'll run multiple integration tests with `invoke local`
+sequentially. To improve this, you can do one compile and run multiple invokes on the
+compiled output -  it is not necessary to compile again before each and every invoke.
+
+```bash
+$ serverless webpack
+$ serverless invoke local --function <function-name-1> --no-build
+$ serverless invoke local --function <function-name-2> --no-build
+...
+```
+
 ### Run a function locally on source changes
 
 Or to run a function every time the source files change use the `--watch` option

--- a/index.js
+++ b/index.js
@@ -112,9 +112,14 @@ class ServerlessWebpack {
       'before:invoke:local:invoke': () => BbPromise.bind(this)
         .then(() => {
           lib.webpack.isLocal = true;
+          // --no-build override
+          if (this.options.build === false) {
+            this.skipCompile = true;
+          }
+
           return this.serverless.pluginManager.spawn('webpack:validate');
         })
-        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+        .then(() => this.skipCompile ? BbPromise.resolve() : this.serverless.pluginManager.spawn('webpack:compile'))
         .then(this.prepareLocalInvoke),
 
       'after:invoke:local:invoke': () => BbPromise.bind(this)
@@ -181,7 +186,7 @@ class ServerlessWebpack {
           lib.webpack.isLocal = true;
         })
         .then(this.prepareStepOfflineInvoke)
-        .then(this.compile)
+        .then(() => this.serverless.pluginManager.spawn('webpack:compile')),
     };
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -357,7 +357,8 @@ describe('ServerlessWebpack', () => {
             .then(() => {
               expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
               expect(slsw.prepareStepOfflineInvoke).to.have.been.calledOnce;
-              expect(slsw.compile).to.have.been.calledOnce;
+              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledOnce;
+              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledWithExactly('webpack:compile');
               return null;
             });
           });

--- a/index.test.js
+++ b/index.test.js
@@ -200,6 +200,17 @@ describe('ServerlessWebpack', () => {
               return null;
             });
           });
+
+          it('should skip compile if requested', () => {
+            slsw.options.build = false;
+            return expect(slsw.hooks['before:invoke:local:invoke']()).to.be.fulfilled
+            .then(() => {
+              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledOnce;
+              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledWithExactly('webpack:validate');
+              expect(slsw.prepareLocalInvoke).to.have.been.calledOnce;
+              return null;
+            });
+          });
         }
       },
       {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -143,6 +143,15 @@ module.exports = {
       this.webpackConfig.output.path = path.join(this.serverless.config.servicePath, this.options.out);
     }
 
+    if (this.skipCompile) {
+      this.serverless.cli.log('Skipping build and using existing compiled output');
+      if (!fse.pathExistsSync(this.webpackConfig.output.path)) {
+        return BbPromise.reject(new this.serverless.classes
+          .Error('No compiled output found'));
+      }
+      this.keepOutputDirectory = true;
+    }
+
     if (!this.keepOutputDirectory) {
       this.options.verbose && this.serverless.cli.log(`Removing ${this.webpackConfig.output.path}`);
       fse.removeSync(this.webpackConfig.output.path);

--- a/tests/mocks/fs-extra.mock.js
+++ b/tests/mocks/fs-extra.mock.js
@@ -8,6 +8,7 @@ module.exports.create = sandbox => {
   const fsExtraMock = {
     copy: sandbox.stub().yields(),
     pathExists: sandbox.stub().yields(),
+    pathExistsSync: sandbox.stub().returns(false),
     removeSync: sandbox.stub()
   };
 

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -53,6 +53,7 @@ describe('validate', () => {
 
   afterEach(() => {
     fsExtraMock.removeSync.reset();
+    fsExtraMock.pathExistsSync.reset();
     sandbox.restore();
   });
 
@@ -733,6 +734,38 @@ describe('validate', () => {
         });
       });
     });
+  });
 
+  describe('with skipped builds', () => {
+    it('should keep output directory', () => {
+      const testConfig = {
+        entry: 'test',
+        output: {},
+      };
+      const testServicePath = 'testpath';
+      module.serverless.config.servicePath = testServicePath;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
+      module.skipCompile = true;
+      fsExtraMock.pathExistsSync.returns(true);
+      return module
+      .validate()
+      .then(() => {
+        expect(module.keepOutputDirectory).to.be.true;
+        return null;
+      });
+    });
+
+    it('should fail without exiting output', () => {
+      const testConfig = {
+        entry: 'test',
+        output: {},
+      };
+      const testServicePath = 'testpath';
+      module.serverless.config.servicePath = testServicePath;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
+      module.skipCompile = true;
+      fsExtraMock.pathExistsSync.returns(false);
+      return expect(module.validate()).to.be.rejectedWith(/No compiled output found/);
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #341 
Closes #275 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

On invoke local we check for a `--no-build` command line switch now and skip the compile step. This enables the requested feature, so that on your CI server where tests are run, you just do a single `sls webpack` and multiple `invoke local --no-build` to fire mutliple integration tests onto one build output.
However, enabling local invoke mode `--watch` together with the switch is not recommended and will _NOT_ disable the compile (somehow that's implicit).

The operation with the new switch will be aborted if the plugin does not find a webpack output directory (i.e. no compile was done before). Additionally a message will be logged as soon as the switch is used.

Off-Topic: Fixed an issue with event spawn for the step offline plugin in this PR.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Use the following steps and check that a compile is not triggered by invoke local:

```
sls webpack
sls invoke local --no-build --function=XXXXX
sls invoke local --no-build --function=YYYYY
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
