### PR TITLE
Do not swallow errors in case npm ls fails without an empty stdout and use spawn for child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ custom:
     webpackConfig: 'webpack.config.js'   # Name of webpack configuration file
     includeModules: false   # Node modules configuration for packaging
     packager: 'npm'   # Packager that will be used to package your external modules
-    packExternalModulesMaxBuffer: 200 * 1024   # Size of stdio buffers for spawned child processes
 ```
 
 ### Webpack configuration file

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -13,7 +13,6 @@ const DefaultConfig = {
   includeModules: false,
   packager: 'npm',
   packagerOptions: {},
-  packExternalModulesMaxBuffer: 200 * 1024,
   config: null
 };
 
@@ -32,7 +31,6 @@ class Configuration {
         this._hasLegacyConfig = true;
       }
       if (custom.packExternalModulesMaxBuffer) {
-        this._config.packExternalModulesMaxBuffer = custom.packExternalModulesMaxBuffer;
         this._hasLegacyConfig = true;
       }
       if (_.isString(custom.webpack)) {
@@ -53,10 +51,6 @@ class Configuration {
 
   get includeModules() {
     return this._config.includeModules;
-  }
-
-  get packExternalModulesMaxBuffer() {
-    return this._config.packExternalModulesMaxBuffer;
   }
 
   get packager() {

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -30,9 +30,6 @@ class Configuration {
         this._config.includeModules = custom.webpackIncludeModules;
         this._hasLegacyConfig = true;
       }
-      if (custom.packExternalModulesMaxBuffer) {
-        this._hasLegacyConfig = true;
-      }
       if (_.isString(custom.webpack)) {
         this._config.webpackConfig = custom.webpack;
         this._hasLegacyConfig = true;

--- a/lib/Configuration.test.js
+++ b/lib/Configuration.test.js
@@ -18,7 +18,6 @@ describe('Configuration', () => {
         includeModules: false,
         packager: 'npm',
         packagerOptions: {},
-        packExternalModulesMaxBuffer: 200 * 1024,
         config: null
       };
     });
@@ -41,12 +40,6 @@ describe('Configuration', () => {
       const testCustom = { webpackIncludeModules: { forceInclude: ['mod1'] } };
       const config = new Configuration(testCustom);
       expect(config).to.have.a.property('includeModules').that.deep.equals(testCustom.webpackIncludeModules);
-    });
-
-    it('should use custom.packExternalModulesMaxBuffer', () => {
-      const testCustom = { packExternalModulesMaxBuffer: 4711 };
-      const config = new Configuration(testCustom);
-      expect(config).to.have.a.property('packExternalModulesMaxBuffer').that.equals(4711);
     });
 
     it('should use custom.webpack as string', () => {
@@ -73,7 +66,6 @@ describe('Configuration', () => {
         includeModules: { forceInclude: ['mod1'] },
         packager: 'npm',
         packagerOptions: {},
-        packExternalModulesMaxBuffer: 200 * 1024,
         config: null
       });
     });
@@ -93,7 +85,6 @@ describe('Configuration', () => {
         includeModules: { forceInclude: ['mod1'] },
         packager: 'npm',
         packagerOptions: {},
-        packExternalModulesMaxBuffer: 200 * 1024,
         config: null
       });
     });
@@ -112,7 +103,6 @@ describe('Configuration', () => {
         includeModules: { forceInclude: ['mod1'] },
         packager: 'npm',
         packagerOptions: {},
-        packExternalModulesMaxBuffer: 200 * 1024,
         config: null
       });
     });

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -195,9 +195,8 @@ module.exports = {
     .then(packager => {
       // Get first level dependency graph
       this.options.verbose && this.serverless.cli.log(`Fetch dependency graph from ${packageJsonPath}`);
-      const maxExecBufferSize = this.configuration.packExternalModulesMaxBuffer;
 
-      return packager.getProdDependencies(path.dirname(packageJsonPath), 1, maxExecBufferSize)
+      return packager.getProdDependencies(path.dirname(packageJsonPath), 1)
       .then(dependencyGraph => {
         const problems = _.get(dependencyGraph, 'problems', []);
         if (this.options.verbose && !_.isEmpty(problems)) {
@@ -271,7 +270,7 @@ module.exports = {
         .then(() => {
           const start = _.now();
           this.serverless.cli.log('Packing external modules: ' + compositeModules.join(', '));
-          return packager.install(compositeModulePath, maxExecBufferSize, this.configuration.packagerOptions)
+          return packager.install(compositeModulePath, this.configuration.packagerOptions)
           .then(() => this.options.verbose && this.serverless.cli.log(`Package took [${_.now() - start} ms]`))
           .return(stats.stats);
         })
@@ -320,13 +319,13 @@ module.exports = {
           .then(() => {
             // Prune extraneous packages - removes not needed ones
             const startPrune = _.now();
-            return packager.prune(modulePath, maxExecBufferSize, this.configuration.packagerOptions)
+            return packager.prune(modulePath, this.configuration.packagerOptions)
             .tap(() => this.options.verbose && this.serverless.cli.log(`Prune: ${modulePath} [${_.now() - startPrune} ms]`));
           })
           .then(() => {
             // Prune extraneous packages - removes not needed ones
             const startRunScripts = _.now();
-            return packager.runScripts(modulePath, maxExecBufferSize, _.keys(packageScripts))
+            return packager.runScripts(modulePath, _.keys(packageScripts))
             .tap(() => this.options.verbose && this.serverless.cli.log(`Run scripts: ${modulePath} [${_.now() - startRunScripts} ms]`));
           });
         })

--- a/lib/packagers/index.js
+++ b/lib/packagers/index.js
@@ -7,11 +7,11 @@
  * interface Packager {
  * 
  * static get lockfileName(): string;
- * static getProdDependencies(cwd: string, depth: number = 1, maxExecBufferSize = undefined): BbPromise<Object>;
+ * static getProdDependencies(cwd: string, depth: number = 1): BbPromise<Object>;
  * static rebaseLockfile(pathToPackageRoot: string, lockfile: Object): void;
- * static install(cwd: string, maxExecBufferSize = undefined): BbPromise<void>;
+ * static install(cwd: string): BbPromise<void>;
  * static prune(cwd: string): BbPromise<void>;
- * static runScripts(cwd: string, maxExecBufferSize, scriptNames): BbPromise<void>;
+ * static runScripts(cwd: string, scriptNames): BbPromise<void>;
  * 
  * }
  */

--- a/lib/packagers/npm.js
+++ b/lib/packagers/npm.js
@@ -5,7 +5,7 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
-const childProcess = require('child_process');
+const Utils = require('../utils');
 
 class NPM {
   static get lockfileName() {  // eslint-disable-line lodash/prefer-constant
@@ -16,9 +16,15 @@ class NPM {
     return true;
   }
 
-  static getProdDependencies(cwd, depth, maxExecBufferSize) {
+  static getProdDependencies(cwd, depth) {
     // Get first level dependency graph
-    const command = `npm ls -prod -json -depth=${depth || 1}`;  // Only prod dependencies
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    const args = [
+      'ls',
+      '-prod',  // Only prod dependencies
+      '-json',
+      `-depth=${depth || 1}`
+    ];
 
     const ignoredNpmErrors = [
       { npmError: 'extraneous', log: false },
@@ -26,29 +32,28 @@ class NPM {
       { npmError: 'peer dep missing', log: true },
     ];
 
-    return BbPromise.fromCallback(cb => {
-      childProcess.exec(command, {
-        cwd: cwd,
-        maxBuffer: maxExecBufferSize,
-        encoding: 'utf8'
-      }, (err, stdout, stderr) => {
-        if (err) {
-          // Only exit with an error if we have critical npm errors for 2nd level inside
-          const errors = _.split(stderr, '\n');
-          const failed = _.reduce(errors, (failed, error) => {
-            if (failed) {
-              return true;
-            }
-            return !_.isEmpty(error) && !_.some(ignoredNpmErrors, ignoredError => _.startsWith(error, `npm ERR! ${ignoredError.npmError}`));
-          }, false);
-
-          if (failed) {
-            return cb(err);
-          }
-        }
-        return cb(null, stdout);
-      });
+    return Utils.spawnProcess(command, args, {
+      cwd: cwd
     })
+    .catch(err => {
+      if (err instanceof Utils.SpawnError) {
+        // Only exit with an error if we have critical npm errors for 2nd level inside
+        const errors = _.split(err.stderr, '\n');
+        const failed = _.reduce(errors, (failed, error) => {
+          if (failed) {
+            return true;
+          }
+          return !_.isEmpty(error) && !_.some(ignoredNpmErrors, ignoredError => _.startsWith(error, `npm ERR! ${ignoredError.npmError}`));
+        }, false);
+
+        if (!failed && !_.isEmpty(err.stdout)) {
+          return BbPromise.resolve({ stdout: err.stdout });
+        }
+      }
+
+      return BbPromise.reject(err);
+    })
+    .then(processOutput => processOutput.stdout)
     .then(depJson => BbPromise.try(() => JSON.parse(depJson)));
   }
 
@@ -73,36 +78,32 @@ class NPM {
     }
   }
   
-  static install(cwd, maxExecBufferSize) {
-    return BbPromise.fromCallback(cb => {
-      childProcess.exec('npm install', {
-        cwd: cwd,
-        maxBuffer: maxExecBufferSize,
-        encoding: 'utf8'
-      }, cb);
-    })
+  static install(cwd) {
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    const args = ['install'];
+
+    return Utils.spawnProcess(command, args, { cwd })
     .return();
   }
 
-  static prune(cwd, maxExecBufferSize) {
-    return BbPromise.fromCallback(cb => {
-      childProcess.exec('npm prune', {
-        cwd: cwd,
-        maxBuffer: maxExecBufferSize,
-        encoding: 'utf8'
-      }, cb);
-    })
+  static prune(cwd) {
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    const args = ['prune'];
+
+    return Utils.spawnProcess(command, args, { cwd })
     .return();
   }
 
-  static runScripts(cwd, maxExecBufferSize, scriptNames) {
-    return BbPromise.mapSeries(scriptNames, scriptName => BbPromise.fromCallback(cb => {
-      childProcess.exec(`npm run ${scriptName}`, {
-        cwd: cwd,
-        maxBuffer: maxExecBufferSize,
-        encoding: 'utf8'
-      }, cb);
-    }))
+  static runScripts(cwd, scriptNames) {
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    return BbPromise.mapSeries(scriptNames, scriptName => {
+      const args = [
+        'run',
+        scriptName
+      ];
+  
+      return Utils.spawnProcess(command, args, { cwd });
+    })
     .return();
   }
 }

--- a/lib/packagers/npm.test.js
+++ b/lib/packagers/npm.test.js
@@ -7,10 +7,7 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const chai = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
-
-// Mocks
-const childProcessMockFactory = require('../../tests/mocks/child_process.mock');
+const Utils = require('../utils');
 
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
@@ -21,24 +18,15 @@ describe('npm', () => {
   let sandbox;
   let npmModule;
 
-  // Mocks
-  let childProcessMock;
-
   before(() => {
     sandbox = sinon.sandbox.create();
     sandbox.usingPromise(BbPromise.Promise);
 
-    childProcessMock = childProcessMockFactory.create(sandbox);
-
-    mockery.enable({ useCleanCache: true, warnOnUnregistered: false });
-    mockery.registerMock('child_process', childProcessMock);
+    sandbox.stub(Utils, 'spawnProcess');
     npmModule = require('./npm');
   });
 
   after(() => {
-    mockery.disable();
-    mockery.deregisterAll();
-
     sandbox.restore();
   });
 
@@ -56,19 +44,17 @@ describe('npm', () => {
 
   describe('install', () => {
     it('should use npm install', () => {
-      childProcessMock.exec.yields(null, 'installed successfully', '');
-      return expect(npmModule.install('myPath', 2000)).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(npmModule.install('myPath')).to.be.fulfilled
       .then(result => {
         expect(result).to.be.undefined;
-        expect(childProcessMock.exec).to.have.been.calledOnce;
-        expect(childProcessMock.exec).to.have.been.calledWithExactly(
-          'npm install',
+        expect(Utils.spawnProcess).to.have.been.calledOnce;
+        expect(Utils.spawnProcess).to.have.been.calledWithExactly(
+          sinon.match(/^npm/),
+          ['install'],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
         return null;
       });
@@ -77,19 +63,17 @@ describe('npm', () => {
 
   describe('prune', () => {
     it('should use npm prune', () => {
-      childProcessMock.exec.yields(null, 'success', '');
-      return expect(npmModule.prune('myPath', 2000)).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: 'success', stderr: '' }));
+      return expect(npmModule.prune('myPath')).to.be.fulfilled
       .then(result => {
         expect(result).to.be.undefined;
-        expect(childProcessMock.exec).to.have.been.calledOnce;
-        expect(childProcessMock.exec).to.have.been.calledWithExactly(
-          'npm prune',
+        expect(Utils.spawnProcess).to.have.been.calledOnce;
+        expect(Utils.spawnProcess).to.have.been.calledWithExactly(
+          sinon.match(/^npm/),
+          ['prune'],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
         return null;
       });
@@ -98,28 +82,24 @@ describe('npm', () => {
 
   describe('runScripts', () => {
     it('should use npm run for the given scripts', () => {
-      childProcessMock.exec.yields(null, 'success', '');
-      return expect(npmModule.runScripts('myPath', 2000, [ 's1', 's2' ])).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: 'success', stderr: '' }));
+      return expect(npmModule.runScripts('myPath', [ 's1', 's2' ])).to.be.fulfilled
       .then(result => {
         expect(result).to.be.undefined;
-        expect(childProcessMock.exec).to.have.been.calledTwice;
-        expect(childProcessMock.exec.firstCall).to.have.been.calledWithExactly(
-          'npm run s1',
+        expect(Utils.spawnProcess).to.have.been.calledTwice;
+        expect(Utils.spawnProcess.firstCall).to.have.been.calledWithExactly(
+          sinon.match(/^npm/),
+          [ 'run', 's1' ],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
-        expect(childProcessMock.exec.secondCall).to.have.been.calledWithExactly(
-          'npm run s2',
+        expect(Utils.spawnProcess.secondCall).to.have.been.calledWithExactly(
+          sinon.match(/^npm/),
+          [ 'run', 's2' ],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
         return null;
       });
@@ -128,26 +108,28 @@ describe('npm', () => {
 
   describe('getProdDependencies', () => {
     it('should use npm ls', () => {
-      childProcessMock.exec.yields(null, '{}', '');
-      return expect(npmModule.getProdDependencies('myPath', 10, 2000)).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: '{}', stderr: '' }));
+      return expect(npmModule.getProdDependencies('myPath', 10)).to.be.fulfilled
       .then(result => {
         expect(result).to.be.an('object').that.is.empty;
-        expect(childProcessMock.exec).to.have.been.calledOnce,
-        expect(childProcessMock.exec.firstCall).to.have.been.calledWith(
-          'npm ls -prod -json -depth=10'
+        expect(Utils.spawnProcess).to.have.been.calledOnce,
+        expect(Utils.spawnProcess.firstCall).to.have.been.calledWith(
+          sinon.match(/^npm/),
+          [ 'ls', '-prod', '-json', '-depth=10' ]
         );
         return null;
       });
     });
 
     it('should default to depth 1', () => {
-      childProcessMock.exec.yields(null, '{}', '');
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: '{}', stderr: '' }));
       return expect(npmModule.getProdDependencies('myPath')).to.be.fulfilled
       .then(result => {
         expect(result).to.be.an('object').that.is.empty;
-        expect(childProcessMock.exec).to.have.been.calledOnce,
-        expect(childProcessMock.exec.firstCall).to.have.been.calledWith(
-          'npm ls -prod -json -depth=1'
+        expect(Utils.spawnProcess).to.have.been.calledOnce,
+        expect(Utils.spawnProcess.firstCall).to.have.been.calledWith(
+          sinon.match(/^npm/),
+          [ 'ls', '-prod', '-json', '-depth=1' ]
         );
         return null;
       });
@@ -156,14 +138,28 @@ describe('npm', () => {
 
   it('should reject if npm returns critical and minor errors', () => {
     const stderr = 'ENOENT: No such file\nnpm ERR! extraneous: sinon@2.3.8 ./babel-dynamically-entries/node_modules/serverless-webpack/node_modules/sinon\n\n';
-    childProcessMock.exec.yields(new Error('something went wrong'), '{}', stderr);
-    return expect(npmModule.getProdDependencies('myPath', 1)).to.be.rejectedWith('something went wrong')
+    Utils.spawnProcess.returns(BbPromise.reject(new Utils.SpawnError('Command execution failed', '{}', stderr)));
+    return expect(npmModule.getProdDependencies('myPath', 1)).to.be.rejectedWith('Command execution failed')
     .then(() => BbPromise.all([
       // npm ls and npm prune should have been called
-      expect(childProcessMock.exec).to.have.been.calledOnce,
-      expect(childProcessMock.exec.firstCall).to.have.been.calledWith(
-        'npm ls -prod -json -depth=1'
-      ),
+      expect(Utils.spawnProcess).to.have.been.calledOnce,
+      expect(Utils.spawnProcess.firstCall).to.have.been.calledWith(
+        sinon.match(/^npm/),
+        [ 'ls', '-prod', '-json', '-depth=1' ]
+      )
+    ]));
+  });
+
+  it('should reject if an error happens without any information in stdout', () => {
+    Utils.spawnProcess.returns(BbPromise.reject(new Utils.SpawnError('Command execution failed', '', '')));
+    return expect(npmModule.getProdDependencies('myPath', 1)).to.be.rejectedWith('Command execution failed')
+    .then(() => BbPromise.all([
+      // npm ls and npm prune should have been called
+      expect(Utils.spawnProcess).to.have.been.calledOnce,
+      expect(Utils.spawnProcess.firstCall).to.have.been.calledWith(
+        sinon.match(/^npm/),
+        [ 'ls', '-prod', '-json', '-depth=1' ]
+      )
     ]));
   });
 
@@ -190,13 +186,14 @@ describe('npm', () => {
       }
     };
 
-    childProcessMock.exec.yields(new Error('NPM error'), JSON.stringify(lsResult), stderr);
+    Utils.spawnProcess.returns(BbPromise.reject(new Utils.SpawnError('Command execution failed', JSON.stringify(lsResult), stderr)));
     return expect(npmModule.getProdDependencies('myPath', 1)).to.be.fulfilled
     .then(dependencies => BbPromise.all([
       // npm ls and npm prune should have been called
-      expect(childProcessMock.exec).to.have.been.calledOnce,
-      expect(childProcessMock.exec).to.have.been.calledWith(
-        'npm ls -prod -json -depth=1'
+      expect(Utils.spawnProcess).to.have.been.calledOnce,
+      expect(Utils.spawnProcess.firstCall).to.have.been.calledWith(
+        sinon.match(/^npm/),
+        [ 'ls', '-prod', '-json', '-depth=1' ]
       ),
       expect(dependencies).to.deep.equal(lsResult),
     ]));

--- a/lib/packagers/yarn.js
+++ b/lib/packagers/yarn.js
@@ -9,7 +9,7 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
-const childProcess = require('child_process');
+const Utils = require('../utils');
 
 class Yarn {
   static get lockfileName() {  // eslint-disable-line lodash/prefer-constant
@@ -20,35 +20,40 @@ class Yarn {
     return false;
   }
 
-  static getProdDependencies(cwd, depth, maxExecBufferSize) {
-    const command = `yarn list --depth=${depth || 1} --json --production`;  // Only prod dependencies
+  static getProdDependencies(cwd, depth) {
+    const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
+    const args = [
+      'list',
+      `--depth=${depth || 1}`,
+      '--json',
+      '--production'
+    ];
 
     // If we need to ignore some errors add them here
     const ignoredYarnErrors = [];
 
-    return BbPromise.fromCallback(cb => {
-      childProcess.exec(command, {
-        cwd: cwd,
-        maxBuffer: maxExecBufferSize,
-        encoding: 'utf8'
-      }, (err, stdout, stderr) => {
-        if (err) {
-          // Only exit with an error if we have critical npm errors for 2nd level inside
-          const errors = _.split(stderr, '\n');
-          const failed = _.reduce(errors, (failed, error) => {
-            if (failed) {
-              return true;
-            }
-            return !_.isEmpty(error) && !_.some(ignoredYarnErrors, ignoredError => _.startsWith(error, `error ${ignoredError.yarnError}`));
-          }, false);
-
-          if (failed) {
-            return cb(err);
-          }
-        }
-        return cb(null, stdout);
-      });
+    return Utils.spawnProcess(command, args, {
+      cwd: cwd
     })
+    .catch(err => {
+      if (err instanceof Utils.SpawnError) {
+        // Only exit with an error if we have critical npm errors for 2nd level inside
+        const errors = _.split(err.stderr, '\n');
+        const failed = _.reduce(errors, (failed, error) => {
+          if (failed) {
+            return true;
+          }
+          return !_.isEmpty(error) && !_.some(ignoredYarnErrors, ignoredError => _.startsWith(error, `npm ERR! ${ignoredError.npmError}`));
+        }, false);
+
+        if (!failed && !_.isEmpty(err.stdout)) {
+          return BbPromise.resolve({ stdout: err.stdout });
+        }
+      }
+
+      return BbPromise.reject(err);
+    })
+    .then(processOutput => processOutput.stdout)
     .then(depJson => BbPromise.try(() => JSON.parse(depJson)))
     .then(parsedTree => {
       const convertTrees = trees => _.reduce(trees, (__, tree) => {
@@ -78,35 +83,38 @@ class Yarn {
   static rebaseLockfile(/* pathToPackageRoot, lockfile */) {
   }
 
-  static install(cwd, maxExecBufferSize, packagerOptions) {
-    let command = 'yarn install --frozen-lockfile --non-interactive';
+  static install(cwd, packagerOptions) {
+    const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
+    const args = [
+      'install',
+      '--frozen-lockfile',
+      '--non-interactive'
+    ];
+
     // Convert supported packagerOptions
     if (packagerOptions.ignoreScripts) {
-      command += ' --ignore-scripts';
+      args.push('--ignore-scripts');
     }
-    return BbPromise.fromCallback(cb => {
-      childProcess.exec(command, {
-        cwd: cwd,
-        maxBuffer: maxExecBufferSize,
-        encoding: 'utf8'
-      }, cb);
-    })
+
+    return Utils.spawnProcess(command, args, { cwd })
     .return();
   }
 
   // "Yarn install" prunes automatically
-  static prune(cwd, maxExecBufferSize, packagerOptions) {
-    return Yarn.install(cwd, maxExecBufferSize, packagerOptions);
+  static prune(cwd, packagerOptions) {
+    return Yarn.install(cwd, packagerOptions);
   }
 
-  static runScripts(cwd, maxExecBufferSize, scriptNames) {
-    return BbPromise.mapSeries(scriptNames, scriptName => BbPromise.fromCallback(cb => {
-      childProcess.exec(`yarn run ${scriptName}`, {
-        cwd: cwd,
-        maxBuffer: maxExecBufferSize,
-        encoding: 'utf8'
-      }, cb);
-    }))
+  static runScripts(cwd, scriptNames) {
+    const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
+    return BbPromise.mapSeries(scriptNames, scriptName => {
+      const args = [
+        'run',
+        scriptName
+      ];
+
+      return Utils.spawnProcess(command, args, { cwd });
+    })
     .return();
   }
 }

--- a/lib/packagers/yarn.test.js
+++ b/lib/packagers/yarn.test.js
@@ -6,10 +6,7 @@
 const BbPromise = require('bluebird');
 const chai = require('chai');
 const sinon = require('sinon');
-const mockery = require('mockery');
-
-// Mocks
-const childProcessMockFactory = require('../../tests/mocks/child_process.mock');
+const Utils = require('../utils');
 
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
@@ -20,24 +17,15 @@ describe('yarn', () => {
   let sandbox;
   let yarnModule;
 
-  // Mocks
-  let childProcessMock;
-
   before(() => {
     sandbox = sinon.sandbox.create();
     sandbox.usingPromise(BbPromise.Promise);
 
-    childProcessMock = childProcessMockFactory.create(sandbox);
-
-    mockery.enable({ useCleanCache: true, warnOnUnregistered: false });
-    mockery.registerMock('child_process', childProcessMock);
+    sandbox.stub(Utils, 'spawnProcess');
     yarnModule = require('./yarn');
   });
 
   after(() => {
-    mockery.disable();
-    mockery.deregisterAll();
-
     sandbox.restore();
   });
 
@@ -55,19 +43,15 @@ describe('yarn', () => {
 
   describe('getProdDependencies', () => {
     it('should use yarn list', () => {
-      childProcessMock.exec.yields(null, '{}', '');
-      return expect(yarnModule.getProdDependencies('myPath', 1, 2000)).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: '{}', stderr: '' }));
+      return expect(yarnModule.getProdDependencies('myPath', 1)).to.be.fulfilled
       .then(result => {
         expect(result).to.be.an('object');
-        expect(childProcessMock.exec).to.have.been.calledOnce;
-        expect(childProcessMock.exec).to.have.been.calledWithExactly(
-          'yarn list --depth=1 --json --production',
-          {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+        expect(Utils.spawnProcess).to.have.been.calledOnce,
+        expect(Utils.spawnProcess.firstCall).to.have.been.calledWith(
+          sinon.match(/^yarn/),
+          [ 'list', '--depth=1', '--json', '--production' ],
+          { cwd: 'myPath' }
         );
         return null;
       });
@@ -112,8 +96,8 @@ describe('yarn', () => {
           },
         }
       };
-      childProcessMock.exec.yields(null, testYarnResult, '');
-      return expect(yarnModule.getProdDependencies('myPath', 1, 2000)).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: testYarnResult, stderr: '' }));
+      return expect(yarnModule.getProdDependencies('myPath', 1)).to.be.fulfilled
       .then(result => {
         expect(result).to.deep.equal(expectedResult);
         return null;
@@ -121,8 +105,8 @@ describe('yarn', () => {
     });
 
     it('should reject on critical yarn errors', () => {
-      childProcessMock.exec.yields(new Error('Exited with code 1'), '', 'Yarn failed.\nerror Could not find module.');
-      return expect(yarnModule.getProdDependencies('myPath', 1, 2000)).to.be.rejectedWith('Exited with code 1');
+      Utils.spawnProcess.returns(BbPromise.reject(new Utils.SpawnError('Exited with code 1', '', 'Yarn failed.\nerror Could not find module.')));
+      return expect(yarnModule.getProdDependencies('myPath', 1)).to.be.rejectedWith('Exited with code 1');
     });
 
   });
@@ -138,38 +122,34 @@ describe('yarn', () => {
 
   describe('install', () => {
     it('should use yarn install', () => {
-      childProcessMock.exec.yields(null, 'installed successfully', '');
-      return expect(yarnModule.install('myPath', 2000, {})).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(yarnModule.install('myPath', {})).to.be.fulfilled
       .then(result => {
         expect(result).to.be.undefined;
-        expect(childProcessMock.exec).to.have.been.calledOnce;
-        expect(childProcessMock.exec).to.have.been.calledWithExactly(
-          'yarn install --frozen-lockfile --non-interactive',
+        expect(Utils.spawnProcess).to.have.been.calledOnce;
+        expect(Utils.spawnProcess).to.have.been.calledWithExactly(
+          sinon.match(/^yarn/),
+          [ 'install', '--frozen-lockfile', '--non-interactive' ],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
         return null;
       });
     });
 
     it('should use ignoreScripts option', () => {
-      childProcessMock.exec.yields(null, 'installed successfully', '');
-      return expect(yarnModule.install('myPath', 2000, { ignoreScripts: true })).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(yarnModule.install('myPath', { ignoreScripts: true })).to.be.fulfilled
       .then(result => {
         expect(result).to.be.undefined;
-        expect(childProcessMock.exec).to.have.been.calledOnce;
-        expect(childProcessMock.exec).to.have.been.calledWithExactly(
-          'yarn install --frozen-lockfile --non-interactive --ignore-scripts',
+        expect(Utils.spawnProcess).to.have.been.calledOnce;
+        expect(Utils.spawnProcess).to.have.been.calledWithExactly(
+          sinon.match(/^yarn/),
+          [ 'install', '--frozen-lockfile', '--non-interactive', '--ignore-scripts' ],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
         return null;
       });
@@ -188,10 +168,10 @@ describe('yarn', () => {
     });
 
     it('should call install', () => {
-      return expect(yarnModule.prune('myPath', 2000, {})).to.be.fulfilled
+      return expect(yarnModule.prune('myPath', {})).to.be.fulfilled
       .then(() => {
         expect(installStub).to.have.been.calledOnce;
-        expect(installStub).to.have.been.calledWithExactly('myPath', 2000, {});
+        expect(installStub).to.have.been.calledWithExactly('myPath', {});
         return null;
       });
     });
@@ -199,28 +179,24 @@ describe('yarn', () => {
 
   describe('runScripts', () => {
     it('should use yarn run for the given scripts', () => {
-      childProcessMock.exec.yields(null, 'success', '');
-      return expect(yarnModule.runScripts('myPath', 2000, [ 's1', 's2' ])).to.be.fulfilled
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: 'success', stderr: '' }));
+      return expect(yarnModule.runScripts('myPath', [ 's1', 's2' ])).to.be.fulfilled
       .then(result => {
         expect(result).to.be.undefined;
-        expect(childProcessMock.exec).to.have.been.calledTwice;
-        expect(childProcessMock.exec.firstCall).to.have.been.calledWithExactly(
-          'yarn run s1',
+        expect(Utils.spawnProcess).to.have.been.calledTwice;
+        expect(Utils.spawnProcess.firstCall).to.have.been.calledWithExactly(
+          sinon.match(/^yarn/),
+          [ 'run', 's1' ],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
-        expect(childProcessMock.exec.secondCall).to.have.been.calledWithExactly(
-          'yarn run s2',
+        expect(Utils.spawnProcess.secondCall).to.have.been.calledWithExactly(
+          sinon.match(/^yarn/),
+          [ 'run', 's2' ],
           {
-            cwd: 'myPath',
-            encoding: 'utf8',
-            maxBuffer: 2000
-          },
-          sinon.match.any
+            cwd: 'myPath'
+          }
         );
         return null;
       });

--- a/lib/prepareOfflineInvoke.test.js
+++ b/lib/prepareOfflineInvoke.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+const chai = require('chai');
+const sinon = require('sinon');
+const Serverless = require('serverless');
+
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
+
+describe('prepareOfflineInvoke', () => {
+  let serverless;
+  let baseModule;
+  let module;
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.usingPromise(BbPromise.Promise);
+
+    baseModule = require('./prepareOfflineInvoke');
+    Object.freeze(baseModule);
+  });
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.cli = {
+      log: sandbox.stub()
+    };
+    sandbox.stub(serverless.pluginManager, 'spawn');
+    module = _.assign({
+      serverless,
+      options: {},
+    }, baseModule);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should set service packaging explicitly', () => {
+    serverless.pluginManager.spawn.resolves();
+    serverless.config.servicePath = 'myPath';
+    module.webpackOutputPath = '.';
+    module.serverless.service.package = {};
+
+    return expect(module.prepareOfflineInvoke()).to.be.fulfilled
+    .then(() => {
+      expect(module.serverless.service.package).to.have.a.property('individually').that.is.false;
+      return null;
+    });
+  });
+
+  it('should switch to service packaging', () => {
+    serverless.pluginManager.spawn.resolves();
+    serverless.config.servicePath = 'myPath';
+    module.webpackOutputPath = '.';
+    module.serverless.service.package = {
+      individually: true
+    };
+
+    return expect(module.prepareOfflineInvoke()).to.be.fulfilled
+    .then(() => {
+      expect(module.serverless.service.package).to.have.a.property('individually').that.is.false;
+      return null;
+    });
+  });
+
+  it('should spawn webpack:validate', () => {
+    serverless.pluginManager.spawn.resolves();
+    serverless.config.servicePath = 'myPath';
+    module.webpackOutputPath = '.';
+
+    return expect(module.prepareOfflineInvoke()).to.be.fulfilled
+    .then(() => {
+      expect(serverless.pluginManager.spawn).to.have.been.calledOnce;
+      expect(serverless.pluginManager.spawn).to.have.been.calledWithExactly('webpack:validate');
+      return null;
+    });
+  });
+
+  it('should reject if spawn rejects', () => {
+    serverless.pluginManager.spawn.returns(BbPromise.reject(new Error('spawn failed')));
+    serverless.config.servicePath = 'myPath';
+    module.webpackOutputPath = '.';
+
+    return expect(module.prepareOfflineInvoke()).to.be.rejectedWith('spawn failed');
+  });
+
+  it('should set location if not given by user', () => {
+    serverless.pluginManager.spawn.resolves();
+    serverless.config.servicePath = '.';
+    module.webpackOutputPath = '.';
+
+    return expect(module.prepareOfflineInvoke()).to.be.fulfilled
+    .then(() => {
+      expect(serverless.service).to.have.a.nested.property('custom.serverless-offline.location', 'service');
+      return null;
+    });
+  });
+
+  it('should keep location if set in service config', () => {
+    serverless.pluginManager.spawn.resolves();
+    serverless.config.servicePath = '.';
+    module.webpackOutputPath = '.';
+    _.set(module.serverless, 'service.custom.serverless-offline.location', 'myLocation');
+
+    return expect(module.prepareOfflineInvoke()).to.be.fulfilled
+    .then(() => {
+      expect(serverless.service).to.have.a.nested.property('custom.serverless-offline.location', 'myLocation');
+      return null;
+    });
+  });
+
+  it('should keep location if set in options', () => {
+    serverless.pluginManager.spawn.resolves();
+    serverless.config.servicePath = '.';
+    module.webpackOutputPath = '.';
+    module.options = {
+      location: 'myLocation'
+    };
+
+    return expect(module.prepareOfflineInvoke()).to.be.fulfilled
+    .then(() => {
+      expect(serverless.service).to.not.have.a.nested.property('custom.serverless-offline.location');
+      return null;
+    });
+  });
+});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
+const childProcess = require('child_process');
 
 function guid() {
   function s4() {
@@ -48,8 +49,58 @@ function searchAndProcessCache(moduleName, processor) {
   return BbPromise.resolve();
 }
 
+class SpawnError extends Error {
+  constructor(message, stdout, stderr) {
+    super(message);
+    this.stdout = stdout;
+    this.stderr = stderr;
+  }
+
+  toString() {
+    return `${this.message}\n${this.stderr}`;
+  }
+}
+
+/**
+ * Executes a child process without limitations on stdout and stderr.
+ * On error (exit code is not 0), it rejects with a SpawnProcessError that contains the stdout and stderr streams,
+ * on success it returns the streams in an object.
+ * @param {string} command - Command
+ * @param {string[]} [args] - Arguments
+ * @param {Object} [options] - Options for child_process.spawn
+ */
+function spawnProcess(command, args, options) {
+  return new BbPromise((resolve, reject) => {
+    const child = childProcess.spawn(command, args, options);
+    let stdout = '';
+    let stderr = '';
+    // Configure stream encodings
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    // Listen to stream events
+    child.stdout.on('data', data => {
+      stdout += data;
+    });
+    child.stderr.on('data', data => {
+      stderr += data;
+    });
+    child.on('error', err => {
+      reject(err);
+    });
+    child.on('close', exitCode => {
+      if (exitCode !== 0) {
+        reject(new SpawnError(`${command} ${_.join(args, ' ')} failed with code ${exitCode}`, stdout, stderr));
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+  });
+}
+
 module.exports = {
   guid,
   purgeCache,
   searchAndProcessCache,
+  SpawnError,
+  spawnProcess,
 };

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -1,0 +1,113 @@
+'use strict';
+/**
+ * Unit tests for Configuration.
+ */
+
+const _ = require('lodash');
+const chai = require('chai');
+const sinon = require('sinon');
+const childProcess = require('child_process');
+const Utils = require('./Utils');
+
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
+
+describe('Utils', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  describe('guid', () => {
+    it('should return different unique ids', () => {
+      const guids = [];
+      for (let i=0; i<10; i++) {
+        guids.push(Utils.guid());
+      }
+
+      expect(_.size(_.uniq(guids))).to.equal(10);
+      expect(_.size(_.compact(guids))).to.equal(10);
+    });
+  });
+
+  describe('SpawnError', () => {
+    it('should store stdout and stderr', () => {
+      const err = new Utils.SpawnError('message', 'stdout', 'stderr');
+      expect(err).to.have.a.property('message').that.equals('message');
+      expect(err).to.have.a.property('stdout').that.equals('stdout');
+      expect(err).to.have.a.property('stderr').that.equals('stderr');
+    });
+
+    it('should print message and stderr', () => {
+      const err = new Utils.SpawnError('message', 'stdout', 'stderr');
+
+      expect(err.toString()).to.equal('message\nstderr');
+    });
+  });
+
+  describe('spawnProcess', () => {
+    const childMock = {
+      stdout: {
+        setEncoding: sinon.stub(),
+        on: sinon.stub()
+      },
+      stderr: {
+        setEncoding: sinon.stub(),
+        on: sinon.stub()
+      },
+      on: sinon.stub()
+    };
+
+    beforeEach(() => {
+      sandbox.stub(childProcess, 'spawn').returns(childMock);
+    });
+
+    afterEach(() => {
+      childProcess.spawn.restore();
+    });
+
+    it('should call child_process.spawn', () => {
+      childMock.on.reset();
+      childMock.on.withArgs('close').yields(0);
+      return expect(Utils.spawnProcess('cmd', [])).to.be.fulfilled
+      .then(result => {
+        expect(childProcess.spawn).to.have.been.calledOnce;
+        expect(result).to.have.a.property('stdout').that.is.empty;
+        expect(result).to.have.a.property('stderr').that.is.empty;
+        return null;
+      });
+    });
+
+    it('should return stdout and stderr', () => {
+      childMock.stdout.on.withArgs('data').yields('myOutData');
+      childMock.stderr.on.withArgs('data').yields('myErrData');
+      childMock.on.reset();
+      childMock.on.withArgs('close').yields(0);
+      return expect(Utils.spawnProcess('cmd', [])).to.be.fulfilled
+      .then(result => {
+        expect(result).to.have.a.property('stdout').that.equals('myOutData');
+        expect(result).to.have.a.property('stderr').that.equals('myErrData');
+        return null;
+      });
+    });
+
+    it('should reject on spawn internal error', () => {
+      childMock.on.reset();
+      childMock.on.withArgs('error').yields(new Error('spawn ENOENT'));
+      return expect(Utils.spawnProcess('cmd', [])).to.be.rejectedWith('spawn ENOENT');
+    });
+
+    it('should reject on positive exit code', () => {
+      childMock.on.reset();
+      childMock.on.withArgs('close').yields(1);
+      return expect(Utils.spawnProcess('cmd', [])).to.be.rejectedWith(Utils.SpawnError);
+    });
+  });
+});

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const chai = require('chai');
 const sinon = require('sinon');
 const childProcess = require('child_process');
-const Utils = require('./Utils');
+const Utils = require('./utils');
 
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));

--- a/tests/mocks/child_process.mock.js
+++ b/tests/mocks/child_process.mock.js
@@ -7,6 +7,7 @@
 module.exports.create = sandbox => {
   const childProcessMock = {
     exec: sandbox.stub().yields(),
+    spawn: sandbox.stub().returns(/* child process object */),
     execSync: sandbox.stub().returns('{}')
   };
 


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

If `npm ls` fails the plugin tries to analyze stderr for npm errors that can be ignored. If none are found, it will pass stdout to `JSON.parse()`.
The case that any non-npm error was happening was not handled correctly (e.g. if the stdout maxbuffer size got exceeded by a very big dependency section). The plugin passed the empty stdout to JSON parse and failed there without telling the exact reason for the failure.
Additionally, Node's buffered stdio streams do not work reliably and the `exec` method is not meant to be used for processes that might return data of arbitrary length.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

The packager executables are now executed with `child_process.spawn` which allows for stdio streams of arbitrary length. On execution failure, a proper SpawnError is now thrown that contains the full stdout and stderr streams.
Additionally this eliminates the need of the `packExternalModulesMaxBuffer` buffer configuration which has been removed from the README.
The implementation should seamlessly work as before.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Use a package.json with _many_ dependencies, so that the output of `npm ls` exceeds the max stdout buffer default of 200k with the old serverless-webpack version.
It should work with this branch now.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
