### PR TITLE
added allow exported unnamed func

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -24,7 +24,7 @@ module.exports = {
   validate() {
     const getHandlerFile = handler => {
       // Check if handler is a well-formed path based handler.
-      const handlerEntry = /(.*)\..*?$/.exec(handler);
+      const handlerEntry = /(.*)\..*?$/.exec(handler) || /(.*).*?$/.exec(handler);
       if (handlerEntry) {
         return handlerEntry[1];
       }


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #372 

## How did you implement it:

quick fix to allow unnamed funcs to be packed w/ lib.entries instead of having to specify each one in webpack config

## How can we verify it:

try to package a serverless project w/ an unnamed function

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
