### PR TITLE
Allow prepend and append modules for lib.entries through function web…

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -69,9 +69,21 @@ module.exports = {
       }
       const ext = getEntryExtension(handlerFile);
 
+      // Load prepend/append modules on entry
+      let entryModule = `./${handlerFile}${ext}`;
+      if (serverlessFunction.webpack && serverlessFunction.webpack.entry) {
+        entryModule = [entryModule];
+        if (serverlessFunction.webpack.entry.prepend) {
+          entryModule.unshift(...serverlessFunction.webpack.entry.prepend);
+        }
+        if (serverlessFunction.webpack.entry.append) {
+          entryModule.push(...serverlessFunction.webpack.entry.append);
+        }
+      }
+
       // Create a valid entry key
       return {
-        [handlerFile]: `./${handlerFile}${ext}`
+        [handlerFile]: entryModule
       };
     };
 
@@ -185,10 +197,7 @@ module.exports = {
       );
 
       this.entryFunctions = _.flatMap(entries, (value, key) => {
-        const entry = path.relative('.', value);
-        const entryFile = _.replace(entry, new RegExp(`${path.extname(entry)}$`), '');
-
-        const entryFuncs = _.filter(allEntryFunctions, [ 'handlerFile', entryFile ]);
+        const entryFuncs = _.filter(allEntryFunctions, [ 'handlerFile', key ]);
         if (_.isEmpty(entryFuncs)) {
           // We have to make sure that for each entry there is an entry function item.
           entryFuncs.push({});


### PR DESCRIPTION
…pack config

<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #397

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

- Changed `getEntryForFunction` allowing prepend/append modules for each entry (per function);
- Changed `this.entryFunctions` picking the entry name (actually the handler of `serverless.yml`) instead infering from module entry module of webpack (which could be an array from now).

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

There's a test covering the case.

## Todos:

- [x] Write tests
- [ ] Write documentation (TBD)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources (Needs clarification)
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
