### PR TITLE
includeModules should be true by default

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -10,7 +10,7 @@ const _ = require('lodash');
  */
 const DefaultConfig = {
   webpackConfig: 'webpack.config.js',
-  includeModules: false,
+  includeModules: true,
   packager: 'npm',
   packagerOptions: {},
   config: null


### PR DESCRIPTION
If a module is not bundled, it will automatically package it.
If all modules are bundled, it will package nothing extra. So this is more intuitive.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NOT for most users. I can't why if a module is not bunded, one doesn't want to package it.
