### PR TITLE
Update get version for external transient dependancies for yarn

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -98,8 +98,12 @@ function getProdModules(externalModules, packagePath, dependencyGraph, forceExcl
     } else {
       if (!packageJson.devDependencies || !packageJson.devDependencies[module.external]) {
         // Add transient dependencies if they appear not in the service's dev dependencies
-        const originInfo = _.get(dependencyGraph, 'dependencies', {})[module.origin] || {};
-        moduleVersion = _.get(_.get(originInfo, 'dependencies', {})[module.external], 'version');
+        if (this.configuration.packager !== 'yarn') {
+          const originInfo = _.get(dependencyGraph, 'dependencies', {})[module.origin] || {};
+          moduleVersion = _.get(_.get(originInfo, 'dependencies', {})[module.external], 'version');
+        } else {
+          moduleVersion = _.get(dependencyGraph, `dependencies['${module.external}'].version`);
+        }
         if (!moduleVersion) {
           this.serverless.cli.log(`WARNING: Could not determine version of module ${module.external}`);
         }


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Hi, I don't think the transient dependancy versions are being looked up correctly if you use yarn.

It looks in `dependencyGraph[module.origin].dependencies[module.external].version` but for yarn I think it would just be `dependencyGraph[module.external].version`?

## How did you implement it:

check packager and if yarn use `dependencyGraph[module.external].version` in moduleVersion bit of getProdModules.

This worked for me™ but idk if it's the best way to do it, happy to update this PR if there's a better way to approach this.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

My use case was as follows - 

using serverless-webpack with yarn, including a private npm module that needs to be transpiled/bundled (it contains universal js for SSR).

also using nodeExternals and `includeModules:true`. so that private npm module is whitelisted in nodeExternals, and included in the babel rule in webpack.

before the change in this PR, on running `sls webpack` I would get warnings `WARNING: Could not determine version of XX` where XX is any of the deps in my private module (not directly in the ssr app package.json) and then it would error ```yarn install --frozen-lockfile --non-interactive failed with code 1
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile```

with the change, it finds the nested dep versions and builds correctly.


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO?
