### PR TITLE
Speed up cleanup process

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -1,20 +1,26 @@
 'use strict';
 
+const _ = require('lodash');
 const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 
 module.exports = {
   cleanup() {
     const webpackOutputPath = this.webpackOutputPath;
-
     const keepOutputDirectory = this.keepOutputDirectory;
+    const cli = this.options.verbose ? this.serverless.cli : { log: _.noop };
+
     if (!keepOutputDirectory) {
-      this.options.verbose && this.serverless.cli.log(`Remove ${webpackOutputPath}`);
+      cli.log(`Remove ${webpackOutputPath}`);
       if (this.serverless.utils.dirExistsSync(webpackOutputPath)) {
-        fse.removeSync(webpackOutputPath);
+        // Remove async to speed up process
+        fse
+          .remove(webpackOutputPath)
+          .then(() => cli.log(`Removing ${webpackOutputPath} done`))
+          .catch(error => cli.log(`Error occurred while removing ${webpackOutputPath}: ${error}`));
       }
     } else {
-      this.options.verbose && this.serverless.cli.log(`Keeping ${webpackOutputPath}`);
+      cli.log(`Keeping ${webpackOutputPath}`);
     }
 
     return BbPromise.resolve();

--- a/tests/cleanup.test.js
+++ b/tests/cleanup.test.js
@@ -14,7 +14,7 @@ const expect = chai.expect;
 
 const FseMock = sandbox => ({
   copy: sandbox.stub(),
-  removeSync: sandbox.stub()
+  remove: sandbox.stub()
 });
 
 describe('cleanup', () => {
@@ -47,6 +47,7 @@ describe('cleanup', () => {
     serverless = new Serverless();
     serverless.cli = {
       log: sandbox.stub(),
+      error: sandbox.stub(),
       consoleLog: sandbox.stub()
     };
     dirExistsSyncStub = sandbox.stub(serverless.utils, 'dirExistsSync');
@@ -54,7 +55,9 @@ describe('cleanup', () => {
     module = _.assign(
       {
         serverless,
-        options: {},
+        options: {
+          verbose: true
+        },
         webpackOutputPath: 'my/Output/Path'
       },
       baseModule
@@ -64,42 +67,78 @@ describe('cleanup', () => {
   afterEach(() => {
     // This will reset the webpackMock too
     sandbox.restore();
+    fseMock.remove.reset();
+    serverless.cli.log.reset();
   });
 
   it('should remove output dir if it exists', () => {
     dirExistsSyncStub.returns(true);
-    fseMock.removeSync.reset();
+    fseMock.remove.resolves(true);
 
     return expect(module.cleanup()).to.be.fulfilled.then(() => {
       expect(dirExistsSyncStub).to.have.been.calledOnce;
       expect(dirExistsSyncStub).to.have.been.calledWith('my/Output/Path');
-      expect(fseMock.removeSync).to.have.been.calledOnce;
+      expect(fseMock.remove).to.have.been.calledOnce;
+      expect(serverless.cli.log).to.have.been.calledWith('Removing my/Output/Path done');
       return null;
     });
   });
 
-  it('should not call removeSync if output dir does not exists', () => {
-    dirExistsSyncStub.returns(false);
-    fseMock.removeSync.reset();
+  it('should log nothing is verbose is false', () => {
+    dirExistsSyncStub.returns(true);
+    fseMock.remove.resolves(true);
+
+    module = _.assign(
+      {
+        serverless,
+        options: {
+          verbose: false
+        },
+        webpackOutputPath: 'my/Output/Path'
+      },
+      baseModule
+    );
 
     return expect(module.cleanup()).to.be.fulfilled.then(() => {
       expect(dirExistsSyncStub).to.have.been.calledOnce;
       expect(dirExistsSyncStub).to.have.been.calledWith('my/Output/Path');
-      expect(fseMock.removeSync).to.not.have.been.called;
+      expect(fseMock.remove).to.have.been.calledOnce;
+      expect(serverless.cli.log).not.to.have.been.called;
+      return null;
+    });
+  });
+
+  it('should log an error if it occurs', () => {
+    dirExistsSyncStub.returns(true);
+    fseMock.remove.rejects('remove error');
+
+    return expect(module.cleanup()).to.be.fulfilled.then(() => {
+      expect(serverless.cli.log).to.have.been.calledWith('Error occurred while removing my/Output/Path: remove error');
+
+      return null;
+    });
+  });
+
+  it('should not call remove if output dir does not exists', () => {
+    dirExistsSyncStub.returns(false);
+
+    return expect(module.cleanup()).to.be.fulfilled.then(() => {
+      expect(dirExistsSyncStub).to.have.been.calledOnce;
+      expect(dirExistsSyncStub).to.have.been.calledWith('my/Output/Path');
+      expect(fseMock.remove).to.not.have.been.called;
       return null;
     });
   });
 
   it('should keep output dir if keepOutputDir = true', () => {
     dirExistsSyncStub.returns(true);
-    fseMock.removeSync.reset();
 
     const configuredModule = _.assign({}, module, {
       keepOutputDirectory: true
     });
     return expect(configuredModule.cleanup()).to.be.fulfilled.then(() => {
       expect(dirExistsSyncStub).to.not.have.been.calledOnce;
-      expect(fseMock.removeSync).to.not.have.been.called;
+      expect(fseMock.remove).to.not.have.been.called;
       return null;
     });
   });


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Removing ".webpack" directory may be is very slow on when this directory is huge.

## How did you implement it:

- Performs remove async (no need to wait the remove of this directory before running  the next process)

## How can we verify it:

Run serverless deploy

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
