### PR TITLE
Adds the ability to specify an excludeFiles glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ custom:
     webpackConfig: 'webpack.config.js'   # Name of webpack configuration file
     includeModules: false   # Node modules configuration for packaging
     packager: 'npm'   # Packager that will be used to package your external modules
+    excludeFiles: src/**/*.test.js # Provide a glob for files to ignore
 ```
 
 ### Webpack configuration file
@@ -302,17 +303,17 @@ custom:
 #### Runtime dependencies
 
 If a runtime dependency is detected that is found in the `devDependencies` section and
-so would not be packaged, the plugin will error until you explicitly exclude it (see `forceExclude` below) 
+so would not be packaged, the plugin will error until you explicitly exclude it (see `forceExclude` below)
 or move it to the `dependencies` section.
 
 #### AWS-SDK
 
 An exception for the runtime dependency error is the AWS-SDK. All projects using the AWS-SDK normally
-have it listed in `devDependencies` because AWS provides it already in their Lambda environment. In this case 
+have it listed in `devDependencies` because AWS provides it already in their Lambda environment. In this case
 the aws-sdk is automatically excluded and only an informational message is printed (in `--verbose` mode).
 
 The main reason for the warning is, that silently ignoring anything contradicts the declarative nature
-of Serverless' service definition. So the correct way to define the handling for the aws-sdk is, as 
+of Serverless' service definition. So the correct way to define the handling for the aws-sdk is, as
 you would do for all other excluded modules (see `forceExclude` below).
 
 ```yaml
@@ -339,7 +340,7 @@ custom:
 ```
 
 You should select the packager, that you use to develop your projects, because only
-then locked versions will be handled correctly, i.e. the plugin uses the generated 
+then locked versions will be handled correctly, i.e. the plugin uses the generated
 (and usually committed) package lock file that is created by your favorite packager.
 
 Each packager might support specific options that can be set in the `packagerOptions`
@@ -372,7 +373,7 @@ You can specify custom scripts that are executed after the installation of the f
 has been finished. These are standard packager scripts as they can be used in any `package.json`.
 
 Warning: The use cases for them are very rare and specific and you should investigate first,
-if your use case can be covered with webpack plugins first. They should never access files 
+if your use case can be covered with webpack plugins first. They should never access files
 outside of their current working directory which is the compiled function folder, if any.
 A valid use case would be to start anything available as binary from `node_modules`.
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,25 @@ from a local folder (e.g. `"mymodule": "file:../../myOtherProject/mymodule"`).
 With that you can do test deployments from the local machine with different
 module versions or modules before they are published officially.
 
+#### Exclude Files with similar names
+
+If you have a project structure that uses something like `index.js` and a
+co-located `index.test.js` then you have likely seen an error like:
+`WARNING: More than one matching handlers found for index. Using index.js`
+
+This config option allows you to exlcude files that match a glob from function
+resolution. Just add: `excludeFiles: **/*.test.js` (with whatever glob you want
+to exclude).
+
+```yaml
+# serverless.yml
+custom:
+  webpack:
+    excludeFiles: **/*.test.js
+```
+
+This is also useful for projects that use TypeScript.
+
 #### Examples
 
 You can find an example setups in the [`examples`][link-examples] folder.

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -5,7 +5,7 @@
 
 const _ = require('lodash');
 
-/** 
+/**
  * Plugin defaults
  */
 const DefaultConfig = {
@@ -48,6 +48,10 @@ class Configuration {
 
   get includeModules() {
     return this._config.includeModules;
+  }
+
+  get excludeFiles() {
+    return this._config.excludeFiles;
   }
 
   get packager() {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -33,7 +33,8 @@ module.exports = {
     const getEntryExtension = fileName => {
       const files = glob.sync(`${fileName}.*`, {
         cwd: this.serverless.config.servicePath,
-        nodir: true
+        nodir: true,
+        ignore: this.configuration.excludeFiles ? this.configuration.excludeFiles : undefined
       });
 
       if (_.isEmpty(files)) {
@@ -117,7 +118,7 @@ module.exports = {
         return BbPromise.reject(err);
       }
     }
-    
+
     // Intermediate function to handle async webpack config
     const processConfig = _config => {
       this.webpackConfig = _config;
@@ -220,7 +221,7 @@ module.exports = {
 
       return BbPromise.resolve();
     };
-    
+
     // Webpack config can be a Promise, If it's a Promise wait for resolved config object.
     if (this.webpackConfig && _.isFunction(this.webpackConfig.then)) {
       return BbPromise.resolve(this.webpackConfig.then(config => processConfig(config)));

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -745,6 +745,40 @@ describe('validate', () => {
         });
       });
 
+      it('should call glob with ignore parameter if there is an excludeFiles config', () => {
+        const testOutPath = 'test';
+        const testFunction = 'func1';
+        const testConfig = {
+          entry: 'test',
+          context: 'testcontext',
+          output: {
+            path: testOutPath,
+          },
+        };
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
+        _.set(module.serverless.service, 'custom.webpack.excludeFiles', '**/*.ts');
+        module.serverless.service.functions = testFunctionsConfig;
+        module.options.function = testFunction;
+        globSyncStub.returns(['module1.js']);
+        return expect(module.validate()).to.be.fulfilled
+        .then(() => {
+          const lib = require('../lib/index');
+          const expectedLibEntries = {
+            'module1': './module1.js'
+          };
+
+          expect(lib.entries).to.deep.equal(expectedLibEntries);
+
+          expect(globSyncStub).to.have.been.calledOnceWith('module1.*', {
+            ignore: '**/*.ts',
+            cwd: null,
+            nodir: true
+          });
+          expect(serverless.cli.log).not.to.have.been.called;
+          return null;
+        });
+      });
+
       it('should throw an exception if no handler is found', () => {
         const testOutPath = 'test';
         const testFunction = 'func1';


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #433

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

Fairly trivial, just used the ignore option in glob to exclude files matching the glob.

## How can we verify it:

1. Setup a serverless project with an index.test.js and an index.js that handle a route
2. Start it up and see that you get a warning about duplicate files matching for index
3. Now pull in this PR
4. add the following to your serverless.yml file in the custom > webpack section
`excludeFiles: **/*.test.js`
5. restart serverless
6. see that the warnings are now gone!

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
