### PR TITLE
Disable colors for non-interactive output

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
+const tty = require('tty');
 
 module.exports = {
   compile() {
@@ -20,7 +21,7 @@ module.exports = {
 
         const compileOutputPaths = [];
         const consoleStats = this.webpackConfig.stats || _.get(this, 'webpackConfig[0].stats') || {
-          colors: true,
+          colors: tty.isatty(process.stdout.fd),
           hash: false,
           version: false,
           chunks: false,

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
+const tty = require('tty');
 
 module.exports = {
   wpwatch() {
@@ -23,7 +24,7 @@ module.exports = {
 
     const compiler = webpack(this.webpackConfig);
     const consoleStats = this.webpackConfig.stats || {
-      colors: true,
+      colors: tty.isatty(process.stdout.fd),
       hash: false,
       version: false,
       chunks: false,


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #480 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

Check if stdout is a tty when deciding to use colors or not.

## How can we verify it:

1. Run from tty (interactive shell) to see default still has colors
2. Pipe into a file to see that it doesn't write colors.

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
