### PR TITLE
ability to not follow symlinks when packaging

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -59,7 +59,7 @@ function zip(directory, name, followSymlinks) {
       const stats = followSymlinks ? fs.statSync(fullPath) : fs.lstatSync(fullPath);
 
       if (!stats.isDirectory(fullPath)) {
-        if (stats.isSymbolicLink()) {
+        if (followSymlinks === false && stats.isSymbolicLink()) {
           const resolvedPath = path.relative(directory, fs.realpathSync(fullPath));
           zip.symlink(filePath, resolvedPath);
         } else {

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -23,7 +23,7 @@ function setArtifactPath(funcName, func, artifactPath) {
   }
 }
 
-function zip(directory, name) {
+function zip(directory, name, followSymlinks) {
   const zip = archiver.create('zip');
   // Create artifact in temp path and move it to the package path (if any) later
   const artifactFilePath = path.join(this.serverless.config.servicePath,
@@ -56,14 +56,19 @@ function zip(directory, name) {
         filePath
       );
 
-      const stats = fs.statSync(fullPath);
+      const stats = followSymlinks ? fs.statSync(fullPath) : fs.lstatSync(fullPath);
 
       if (!stats.isDirectory(fullPath)) {
-        zip.append(fs.readFileSync(fullPath), {
-          name: filePath,
-          mode: stats.mode,
-          date: new Date(0), // necessary to get the same hash when zipping the same content
-        });
+        if (stats.isSymbolicLink()) {
+          const resolvedPath = path.relative(directory, fs.realpathSync(fullPath));
+          zip.symlink(filePath, resolvedPath);
+        } else {
+          zip.append(fs.readFileSync(fullPath), {
+            name: filePath,
+            mode: stats.mode,
+            date: new Date(0), // necessary to get the same hash when zipping the same content
+          });
+        }
       }
     });
 
@@ -84,9 +89,12 @@ module.exports = {
       const entryFunction = _.get(this.entryFunctions, index, {});
       const filename = `${entryFunction.funcName || this.serverless.service.getServiceObject().name}.zip`;
       const modulePath = compileStats.compilation.compiler.outputPath;
+      const funcSymlinks = _.get(entryFunction, 'func.package.symlinks', true);
+      const serviceSymlinks = _.get(this.serverless, 'service.package.symlinks', true);
+      const followSymlinks = funcSymlinks === false || serviceSymlinks === false ? false : true;
 
       const startZip = _.now();
-      return zip.call(this, modulePath, filename)
+      return zip.call(this, modulePath, filename, followSymlinks)
       .tap(() => this.options.verbose &&
         this.serverless.cli.log(`Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'}: ${modulePath} [${_.now() - startZip} ms]`))
       .then(artifactPath => {

--- a/tests/mocks/fs.mock.js
+++ b/tests/mocks/fs.mock.js
@@ -12,7 +12,8 @@ const StreamMock = sandbox => ({
 });
 
 const StatMock = sandbox => ({
-  isDirectory: sandbox.stub()
+  isDirectory: sandbox.stub(),
+  isSymbolicLink: sandbox.stub()
 });
 
 module.exports.create = sandbox => {

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -139,6 +139,7 @@ describe('packageModules', () => {
         fsMock._streamMock.on.withArgs('open').yields();
         fsMock._streamMock.on.withArgs('close').yields();
         fsMock._statMock.isDirectory.returns(false);
+        fsMock._statMock.isSymbolicLink.returns(false);
 
         const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
 
@@ -205,6 +206,7 @@ describe('packageModules', () => {
           fsMock._streamMock.on.withArgs('open').yields();
           fsMock._streamMock.on.withArgs('close').yields();
           fsMock._statMock.isDirectory.returns(false);
+          fsMock._statMock.isSymbolicLink.returns(false);
 
           const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
 
@@ -252,6 +254,7 @@ describe('packageModules', () => {
         fsMock._streamMock.on.withArgs('open').yields();
         fsMock._streamMock.on.withArgs('close').yields();
         fsMock._statMock.isDirectory.returns(false);
+        fsMock._statMock.isSymbolicLink.returns(false);
 
         const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
 
@@ -313,6 +316,7 @@ describe('packageModules', () => {
         fsMock._streamMock.on.withArgs('open').yields();
         fsMock._streamMock.on.withArgs('close').yields();
         fsMock._statMock.isDirectory.returns(false);
+        fsMock._statMock.isSymbolicLink.returns(false);
 
         module.compileStats = stats;
         return expect(module.packageModules()).to.be.rejectedWith('Packaging: No files found');
@@ -385,6 +389,7 @@ describe('packageModules', () => {
         fsMock._streamMock.on.withArgs('open').yields();
         fsMock._streamMock.on.withArgs('close').yields();
         fsMock._statMock.isDirectory.returns(false);
+        fsMock._statMock.isSymbolicLink.returns(false);
 
         module.compileStats = stats;
         return expect(module.packageModules()).to.be.fulfilled


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
I needed this, because I built a custom binary of imagemagick to use in lambda, and it contains lots of symlinks. When these symlinks were dereferenced the filesize was 280MB and therefore too large for lambda. I added a `symlink: false` (default is true) flag to individual functions, and allows me to choose whether we want to include dereferenced symlinks or not. Related to https://github.com/serverless/serverless/issues/3215, and I'll probably work on porting it over there, but implemented here first since I use webpack for all of my deploys.

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:
I check if the symlink flag exists and pass an additional parameter to the zip function in packageModules. If we're not following symlinks, then I used lstatSync instead of statSync to get the details about the file, so that we can know if it's a symlink or not. If it is a symlink, I dereference the relative location of the symlink and add it to the package using archiver's `.symlink(file, target)` method added in 2.0.0 (currently serverless-webpack is using 2.1.1).
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Include a large binary file in the lambda function, and then multiple symlinks pointing at that same file and then package it. The packaged zip should contain multiple copies of that binary by default, or only one copy of the binary and soft-symlinks to it if `symlinks: false` is set.

```yaml
functions:
  exampleFunction:
    handler: src/index.handler
    package:
      symlinks: false
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:
I still need to write tests/documentation, but wanted to do those after confirming this is a PR you're willing to accept.

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
