### PR TITLE
add the ability to exclude some files from the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,22 @@ custom:
 This can be useful, in case you want to upload the source maps to your Error
 reporting system, or just have it available for some post processing.
 
+### Include only a subset of built assets
+
+If you don't want all built assets (i.e. js, json, js.map files, etc.) to be included
+in the package, then you can specify the glob value that'll be used to match the files
+to include in the package.
+
+```yaml
+# serverless.yml
+custom:
+  webpack:
+    builtAssetIncludeGlob: "**/*.{js,json}"
+```
+
+This can be useful when you don't want to include the source maps to make the package
+even smaller.
+
 #### Examples
 
 You can find an example setups in the [`examples`][link-examples] folder.

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -14,6 +14,7 @@ const DefaultConfig = {
   packager: 'npm',
   packagerOptions: {},
   keepOutputDirectory: false,
+  builtAssetIncludeGlob: '**',
   config: null
 };
 
@@ -69,6 +70,10 @@ class Configuration {
 
   get keepOutputDirectory() {
     return this._config.keepOutputDirectory;
+  }
+
+  get builtAssetIncludeGlob() {
+    return this._config.builtAssetIncludeGlob;
   }
 
   toJSON() {

--- a/lib/Configuration.test.js
+++ b/lib/Configuration.test.js
@@ -19,6 +19,7 @@ describe('Configuration', () => {
         packager: 'npm',
         packagerOptions: {},
         keepOutputDirectory: false,
+        builtAssetIncludeGlob: '**',
         config: null
       };
     });
@@ -66,6 +67,7 @@ describe('Configuration', () => {
         webpackConfig: 'myWebpackFile.js',
         includeModules: { forceInclude: ['mod1'] },
         packager: 'npm',
+        builtAssetIncludeGlob: '**',
         packagerOptions: {},
         keepOutputDirectory: false,
         config: null
@@ -86,6 +88,7 @@ describe('Configuration', () => {
         webpackConfig: 'myWebpackFile.js',
         includeModules: { forceInclude: ['mod1'] },
         packager: 'npm',
+        builtAssetIncludeGlob: '**',
         packagerOptions: {},
         keepOutputDirectory: false,
         config: null
@@ -105,6 +108,7 @@ describe('Configuration', () => {
         webpackConfig: 'myWebpackFile.js',
         includeModules: { forceInclude: ['mod1'] },
         packager: 'npm',
+        builtAssetIncludeGlob: '**',
         packagerOptions: {},
         keepOutputDirectory: false,
         config: null

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -34,7 +34,7 @@ function zip(directory, name) {
 
   const output = fs.createWriteStream(artifactFilePath);
 
-  const files = glob.sync('**', {
+  const files = glob.sync(this.configuration.builtAssetIncludeGlob, {
     cwd: directory,
     dot: true,
     silent: true,

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -72,6 +72,7 @@ describe('packageModules', () => {
     module = _.assign({
       serverless,
       options: {},
+      configuration: { builtAssetIncludeGlob: '**' },
     }, baseModule);
   });
 


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #470 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

It allows the user to include only a subset of files in the package.<br/>
For example, it's very handy to exclude sourcemaps from the package.

## How did you implement it:
```yaml
# serverless.yml
custom:
  webpack:
    builtAssetIncludeGlob: "**/*.{js,json}"
```

☝️this is how we use it.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
We were already using [glob](https://www.npmjs.com/package/glob) package and passing `**` to include all files, this PR just makes that input to glob package as a configurable value from `serverless.yml`.

If not set in `serverless.yml` it defaults to `**`, including all files.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

1. As described above, just add the option in serverless.yml.
2. Run `sls package`
3. Extract the zip file in `.serverless` and verify that `.js.map` files are not included in the package


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
