### PR TITLE
Converted the watcher.stop() to use built in webpack hooks instead

### DIFF
--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -21,7 +21,44 @@ module.exports = {
       this.serverless.cli.log(`Enabled polling (${watchOptions.poll} ms)`);
     }
 
+    let currentCompileWatch = null;
+
+    // This allows us to hold the compile until "webpack:compile:watch" has resolved
+    const beforeCompile = () => (
+      new BbPromise((resolve) => {
+        // eslint-disable-next-line promise/catch-or-return
+        BbPromise.resolve(currentCompileWatch)
+          // Forwarding the error to the then so we don't display it twice
+          // (once when it was originally thrown, and once when the promise rejects)
+          .catch(error => error)
+          .then((error) => {
+            if (error) {
+              return null;
+            }
+
+            currentCompileWatch = null;
+            resolve();
+            return null;
+          });
+      })
+    );
+
     const compiler = webpack(this.webpackConfig);
+
+    // Determine if we can use hooks or if we should fallback to the plugin api
+    const hasHooks = compiler.hooks && compiler.hooks.beforeCompile;
+    const hasPlugins = compiler.plugin;
+    const canEmit = hasHooks || hasPlugins;
+
+    if (hasHooks) {
+      compiler.hooks.beforeCompile.tapPromise('webpack:compile:watch', beforeCompile);
+    } else if (hasPlugins) {
+      compiler.plugin('before-compile', (compilationParams, callback) => {
+        // eslint-disable-next-line promise/no-callback-in-promise
+        beforeCompile().then(callback).catch(_.noop);
+      });
+    }
+
     const consoleStats = this.webpackConfig.stats || {
       colors: true,
       hash: false,
@@ -32,9 +69,10 @@ module.exports = {
 
     // This starts the watch and waits for the immediate compile that follows to end or fail.
     let lastHash = null;
+
     const startWatch = (callback) => {
       let firstRun = true;
-      const watcher = compiler.watch(watchOptions, (err, stats) => {
+      compiler.watch(watchOptions, (err, stats) => {
         if (err) {
           if (firstRun) {
             firstRun = false;
@@ -65,18 +103,10 @@ module.exports = {
           firstRun = false;
           this.serverless.cli.log('Watching for changes...');
           callback();
-        } else {
-          // We will close the watcher while the compile event is triggered and resume afterwards to prevent race conditions.
-          watcher.close(() => {
-            return this.serverless.pluginManager.spawn('webpack:compile:watch')
-            .then(() => {
-              // Resume watching after we triggered the compile:watch event
-              return BbPromise.fromCallback(cb => {
-                startWatch(cb);
-              })
-              .then(() => this.serverless.cli.log('Watching for changes...'));
-            });
-          });
+        } else if (canEmit && currentCompileWatch === null) {
+          currentCompileWatch = BbPromise.resolve(
+            this.serverless.pluginManager.spawn('webpack:compile:watch')
+          ).then(() => this.serverless.cli.log('Watching for changes...'));
         }
       });
     };

--- a/tests/webpack.mock.js
+++ b/tests/webpack.mock.js
@@ -12,23 +12,23 @@ const StatsMock = () => ({
   toString: sinon.stub().returns('testStats'),
 });
 
-const WatchMock = sandbox => ({
-  close: sandbox.stub().callsFake(cb => cb())
-});
 
-const CompilerMock = (sandbox, statsMock, watchMock) => ({
+const CompilerMock = (sandbox, statsMock) => ({
   run: sandbox.stub().yields(null, statsMock),
-  watch: sandbox.stub().returns(watchMock).yields(null, statsMock)
+  watch: sandbox.stub().yields(null, statsMock),
+  hooks: {
+    beforeCompile: {
+      tapPromise: sandbox.stub()
+    }
+  },
 });
 
 const webpackMock = sandbox => {
   const statsMock = StatsMock(sandbox);
-  const watchMock = WatchMock(sandbox);
-  const compilerMock = CompilerMock(sandbox, statsMock, watchMock);
+  const compilerMock = CompilerMock(sandbox, statsMock);
   const mock = sinon.stub().returns(compilerMock);
   mock.compilerMock = compilerMock;
   mock.statsMock = statsMock;
-  mock.watchMock = watchMock;
   return mock;
 };
 


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The file watcher in webpack is always listening when running in watch mode. A way to get around this was introduces in #319. Since then a few webpack loaders (and probably a few plugins too) are listening to the webpack hook "watchClose" to terminate their processes. Closing the watcher causes a few problems - mainly that the loaders/plugins basically need to restart their processes - and that can be slow.

Both `awesome-typescript-loader` and `fork-ts-checker-webpack-plugin` suffers from this.

Closes #465.
Closes #449.

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:
This PR fixes the aforementioned issue by utilising hooks or plugins (depending on your webpack version), to listen for the event `before-compile`. And then basically "holding" the compilation until the `webpack:compile:watch:compile` has resolved (this event is a resolved promise by default). This means that we don't have to close the watcher, and we can still spawn the event.

It functions the same way it did before.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Use the [linked repository](https://github.com/dwelch2344/serverless-webpack-watch-compile-demo) in #319, but change the serverless-webpack to be this PR instead. You might have to deactivate the `example1`-plugin the first run since it tries to resolve a file that doesn't exist.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
