### PR TITLE
Fix: Empty lines while stats: 'errors-only'

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -29,7 +29,10 @@ module.exports = {
         };
 
         _.forEach(stats.stats, compileStats => {
-          this.serverless.cli.consoleLog(compileStats.toString(consoleStats));
+          const statsOutput = compileStats.toString(consoleStats);
+          if (statsOutput) {
+            this.serverless.cli.consoleLog(statsOutput);
+          }
 
           if (compileStats.compilation.errors.length) {
             throw new Error('Webpack compilation error, see above');

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -97,7 +97,10 @@ module.exports = {
 
         if (stats) {
           lastHash = stats.hash;
-          this.serverless.cli.consoleLog(stats.toString(consoleStats));
+          const statsOutput = stats.toString(consoleStats);
+          if (statsOutput) {
+            this.serverless.cli.consoleLog(stats.toString(consoleStats));
+          }
         }
 
         if (firstRun) {


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless-heaven/serverless-webpack/issues/499

## How did you implement it:

Do not print empty console messages in case if compiled item stats return nothing.

## How can we verify it:

Setup webpack config with `stats: 'errors-only'` and run serverless deploy

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## PS:
It's very simple change that makes logs much more readable