### PR TITLE
Extends the --no-build option to serverless offline start

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,19 +167,27 @@ class ServerlessWebpack {
 
       'before:offline:start': () =>
         BbPromise.bind(this)
-          .tap(() => {
-            lib.webpack.isLocal = true;
-          })
-          .then(this.prepareOfflineInvoke)
-          .then(this.wpwatch),
+        .tap(() => {
+          lib.webpack.isLocal = true;
+          // --no-build override
+          if (this.options.build === false) {
+            this.skipCompile = true;
+          }
+        })
+        .then(this.prepareOfflineInvoke)
+        .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),
 
       'before:offline:start:init': () =>
         BbPromise.bind(this)
           .tap(() => {
             lib.webpack.isLocal = true;
+            // --no-build override
+            if (this.options.build === false) {
+              this.skipCompile = true;
+            }
           })
           .then(this.prepareOfflineInvoke)
-          .then(this.wpwatch),
+          .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),
 
       'before:step-functions-offline:start': () =>
         BbPromise.bind(this)

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ class ServerlessWebpack {
           },
           package: {
             type: 'entrypoint',
-            lifecycleEvents: [ 'packExternalModules', 'packageModules' ],
+            lifecycleEvents: ['packExternalModules', 'packageModules'],
           },
         },
       },
@@ -167,15 +167,17 @@ class ServerlessWebpack {
 
       'before:offline:start': () =>
         BbPromise.bind(this)
-        .tap(() => {
-          lib.webpack.isLocal = true;
-          // --no-build override
-          if (this.options.build === false) {
-            this.skipCompile = true;
-          }
-        })
-        .then(this.prepareOfflineInvoke)
-        .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),
+          .tap(() => {
+            lib.webpack.isLocal = true;
+            // --no-build override
+            if (this.options.build === false) {
+              this.skipCompile = true;
+            }
+          })
+          .then(this.prepareOfflineInvoke)
+          .then(() =>
+            this.skipCompile ? BbPromise.resolve() : this.wpwatch(),
+          ),
 
       'before:offline:start:init': () =>
         BbPromise.bind(this)
@@ -187,7 +189,9 @@ class ServerlessWebpack {
             }
           })
           .then(this.prepareOfflineInvoke)
-          .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),
+          .then(() =>
+            this.skipCompile ? BbPromise.resolve() : this.wpwatch(),
+          ),
 
       'before:step-functions-offline:start': () =>
         BbPromise.bind(this)

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const packageModules = require('./lib/packageModules');
 const lib = require('./lib');
 
 class ServerlessWebpack {
-
   static get lib() {
     return lib;
   }
@@ -28,10 +27,10 @@ class ServerlessWebpack {
 
     if (
       (_.has(this.serverless, 'service.custom.webpack') &&
-      _.isString(this.serverless.service.custom.webpack) &&
-      _.endsWith(this.serverless.service.custom.webpack, '.ts')) ||
+        _.isString(this.serverless.service.custom.webpack) &&
+        _.endsWith(this.serverless.service.custom.webpack, '.ts')) ||
       (_.has(this.serverless, 'service.custom.webpack.webpackConfig') &&
-      _.endsWith(this.serverless.service.custom.webpack.webpackConfig, '.ts'))
+        _.endsWith(this.serverless.service.custom.webpack.webpackConfig, '.ts'))
     ) {
       require('ts-node/register');
     }
@@ -48,15 +47,13 @@ class ServerlessWebpack {
       prepareLocalInvoke,
       runPluginSupport,
       prepareOfflineInvoke,
-      prepareStepOfflineInvoke
+      prepareStepOfflineInvoke,
     );
 
     this.commands = {
       webpack: {
         usage: 'Bundle with Webpack',
-        lifecycleEvents: [
-          'webpack'
-        ],
+        lifecycleEvents: ['webpack'],
         options: {
           out: {
             usage: 'Path to output directory',
@@ -66,127 +63,131 @@ class ServerlessWebpack {
         commands: {
           validate: {
             type: 'entrypoint',
-            lifecycleEvents: [
-              'validate',
-            ],
+            lifecycleEvents: ['validate'],
           },
           compile: {
             type: 'entrypoint',
-            lifecycleEvents: [
-              'compile',
-            ],
+            lifecycleEvents: ['compile'],
             commands: {
               watch: {
                 type: 'entrypoint',
-                lifecycleEvents: [
-                  'compile'
-                ]
-              }
-            }
+                lifecycleEvents: ['compile'],
+              },
+            },
           },
           package: {
             type: 'entrypoint',
-            lifecycleEvents: [
-              'packExternalModules',
-              'packageModules'
-            ],
+            lifecycleEvents: [ 'packExternalModules', 'packageModules' ],
           },
         },
       },
     };
 
     this.hooks = {
-      'before:package:createDeploymentArtifacts': () => BbPromise.bind(this)
-        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
-        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
-        .then(() => this.serverless.pluginManager.spawn('webpack:package')),
+      'before:package:createDeploymentArtifacts': () =>
+        BbPromise.bind(this)
+          .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+          .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+          .then(() => this.serverless.pluginManager.spawn('webpack:package')),
 
-      'after:package:createDeploymentArtifacts': () => BbPromise.bind(this)
-        .then(this.cleanup),
+      'after:package:createDeploymentArtifacts': () =>
+        BbPromise.bind(this).then(this.cleanup),
 
-      'before:deploy:function:packageFunction': () => BbPromise.bind(this)
-        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
-        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
-        .then(() => this.serverless.pluginManager.spawn('webpack:package')),
+      'before:deploy:function:packageFunction': () =>
+        BbPromise.bind(this)
+          .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+          .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+          .then(() => this.serverless.pluginManager.spawn('webpack:package')),
 
-      'before:invoke:local:invoke': () => BbPromise.bind(this)
-        .then(() => {
-          lib.webpack.isLocal = true;
-          // --no-build override
-          if (this.options.build === false) {
-            this.skipCompile = true;
-          }
+      'before:invoke:local:invoke': () =>
+        BbPromise.bind(this)
+          .then(() => {
+            lib.webpack.isLocal = true;
+            // --no-build override
+            if (this.options.build === false) {
+              this.skipCompile = true;
+            }
 
-          return this.serverless.pluginManager.spawn('webpack:validate');
-        })
-        .then(() => this.skipCompile ? BbPromise.resolve() : this.serverless.pluginManager.spawn('webpack:compile'))
-        .then(this.prepareLocalInvoke),
+            return this.serverless.pluginManager.spawn('webpack:validate');
+          })
+          .then(() =>
+            this.skipCompile
+              ? BbPromise.resolve()
+              : this.serverless.pluginManager.spawn('webpack:compile'),
+          )
+          .then(this.prepareLocalInvoke),
 
-      'after:invoke:local:invoke': () => BbPromise.bind(this)
-        .then(() => {
+      'after:invoke:local:invoke': () =>
+        BbPromise.bind(this).then(() => {
           if (this.options.watch && !this.isWatching) {
             return this.watch('invoke:local');
           }
           return BbPromise.resolve();
         }),
 
-      'before:run:run': () => BbPromise.bind(this)
-        .then(() => _.set(this.serverless, 'service.package.individually', false))
-        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
-        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
-        .then(this.packExternalModules)
-        .then(this.prepareRun),
+      'before:run:run': () =>
+        BbPromise.bind(this)
+          .then(() =>
+            _.set(this.serverless, 'service.package.individually', false),
+          )
+          .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+          .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+          .then(this.packExternalModules)
+          .then(this.prepareRun),
 
-      'after:run:run': () => BbPromise.bind(this)
-        .then(() => {
+      'after:run:run': () =>
+        BbPromise.bind(this).then(() => {
           if (this.options.watch && !this.isWatching) {
             return this.watch(this.watchRun.bind(this));
           }
           return BbPromise.resolve();
         }),
 
-      'webpack:webpack': () => BbPromise.bind(this)
-        .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
-        .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
-        .then(() => this.serverless.pluginManager.spawn('webpack:package')),
+      'webpack:webpack': () =>
+        BbPromise.bind(this)
+          .then(() => this.serverless.pluginManager.spawn('webpack:validate'))
+          .then(() => this.serverless.pluginManager.spawn('webpack:compile'))
+          .then(() => this.serverless.pluginManager.spawn('webpack:package')),
 
       /*
        * Internal webpack events (can be hooked by plugins)
        */
-      'webpack:validate:validate': () => BbPromise.bind(this)
-        .then(this.validate),
+      'webpack:validate:validate': () =>
+        BbPromise.bind(this).then(this.validate),
 
-      'webpack:compile:compile': () => BbPromise.bind(this)
-        .then(this.compile),
+      'webpack:compile:compile': () => BbPromise.bind(this).then(this.compile),
 
       'webpack:compile:watch:compile': () => BbPromise.resolve(),
 
-      'webpack:package:packExternalModules': () => BbPromise.bind(this)
-        .then(this.packExternalModules),
+      'webpack:package:packExternalModules': () =>
+        BbPromise.bind(this).then(this.packExternalModules),
 
-      'webpack:package:packageModules': () => BbPromise.bind(this)
-        .then(this.packageModules),
+      'webpack:package:packageModules': () =>
+        BbPromise.bind(this).then(this.packageModules),
 
-      'before:offline:start': () => BbPromise.bind(this)
-        .tap(() => {
-          lib.webpack.isLocal = true;
-        })
-        .then(this.prepareOfflineInvoke)
-        .then(this.wpwatch),
+      'before:offline:start': () =>
+        BbPromise.bind(this)
+          .tap(() => {
+            lib.webpack.isLocal = true;
+          })
+          .then(this.prepareOfflineInvoke)
+          .then(this.wpwatch),
 
-      'before:offline:start:init': () => BbPromise.bind(this)
-        .tap(() => {
-          lib.webpack.isLocal = true;
-        })
-        .then(this.prepareOfflineInvoke)
-        .then(this.wpwatch),
+      'before:offline:start:init': () =>
+        BbPromise.bind(this)
+          .tap(() => {
+            lib.webpack.isLocal = true;
+          })
+          .then(this.prepareOfflineInvoke)
+          .then(this.wpwatch),
 
-      'before:step-functions-offline:start': () => BbPromise.bind(this)
-        .tap(() => {
-          lib.webpack.isLocal = true;
-        })
-        .then(this.prepareStepOfflineInvoke)
-        .then(() => this.serverless.pluginManager.spawn('webpack:compile')),
+      'before:step-functions-offline:start': () =>
+        BbPromise.bind(this)
+          .tap(() => {
+            lib.webpack.isLocal = true;
+          })
+          .then(this.prepareStepOfflineInvoke)
+          .then(() => this.serverless.pluginManager.spawn('webpack:compile')),
     };
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -27,7 +27,7 @@ describe('ServerlessWebpack', () => {
 
     sandbox = sinon.createSandbox();
 
-    mockery.enable({ useCleanCache: true, warnOnUnregistered: false });
+    mockery.enable({useCleanCache: true, warnOnUnregistered: false});
     mockery.registerMock('ts-node/register', {});
     mockery.registerMock('webpack', {});
 
@@ -39,10 +39,12 @@ describe('ServerlessWebpack', () => {
     serverless = new Serverless();
     serverless.cli = {
       log: sandbox.stub(),
-      consoleLog: sandbox.stub()
+      consoleLog: sandbox.stub(),
     };
 
-    sandbox.stub(serverless.pluginManager, 'spawn').returns(BbPromise.resolve());
+    sandbox
+      .stub(serverless.pluginManager, 'spawn')
+      .returns(BbPromise.resolve());
   });
 
   afterEach(() => {
@@ -58,10 +60,15 @@ describe('ServerlessWebpack', () => {
   it('should expose a lib object', () => {
     const lib = ServerlessWebpack.lib;
     expect(lib).to.be.an('object');
-    expect(lib).to.have.a.property('entries').that.is.an('object').that.is.empty;
-    expect(lib).to.have.a.property('webpack').that.is.an('object').that.deep.equals({
-      isLocal: false
-    });
+    expect(lib)
+      .to.have.a.property('entries')
+      .that.is.an('object').that.is.empty;
+    expect(lib)
+      .to.have.a.property('webpack')
+      .that.is.an('object')
+      .that.deep.equals({
+        isLocal: false,
+      });
   });
 
   describe('with a TS webpack configuration', () => {
@@ -73,7 +80,11 @@ describe('ServerlessWebpack', () => {
     });
 
     it('should support new config and register ts-node', () => {
-      _.set(serverless, 'service.custom.webpack.webpackConfig', 'webpack.config.ts');
+      _.set(
+        serverless,
+        'service.custom.webpack.webpackConfig',
+        'webpack.config.ts',
+      );
       new ServerlessWebpack(serverless, {});
       expect(Module._load).to.have.been.calledOnce;
       expect(Module._load).to.have.been.calledWith('ts-node/register');
@@ -88,18 +99,23 @@ describe('ServerlessWebpack', () => {
     });
   });
 
-  _.forEach([
-    'commands.webpack',
-    'commands.webpack.commands.validate',
-    'commands.webpack.commands.compile',
-    'commands.webpack.commands.compile.commands.watch',
-    'commands.webpack.commands.package',
-  ], command => {
-    it(`should expose command/entrypoint ${_.last(_.split(command, '.'))}`, () => {
-      const slsw = new ServerlessWebpack(serverless, {});
-      expect(slsw).to.have.a.nested.property(command);
-    });
-  });
+  _.forEach(
+    [
+      'commands.webpack',
+      'commands.webpack.commands.validate',
+      'commands.webpack.commands.compile',
+      'commands.webpack.commands.compile.commands.watch',
+      'commands.webpack.commands.package',
+    ],
+    (command) => {
+      it(`should expose command/entrypoint ${_.last(
+        _.split(command, '.'),
+      )}`, () => {
+        const slsw = new ServerlessWebpack(serverless, {});
+        expect(slsw).to.have.a.nested.property(command);
+      });
+    },
+  );
 
   describe('hooks', () => {
     let slsw;
@@ -117,7 +133,9 @@ describe('ServerlessWebpack', () => {
       sandbox.stub(slsw, 'packageModules').returns(BbPromise.resolve());
       sandbox.stub(slsw, 'prepareLocalInvoke').returns(BbPromise.resolve());
       sandbox.stub(slsw, 'prepareOfflineInvoke').returns(BbPromise.resolve());
-      sandbox.stub(slsw, 'prepareStepOfflineInvoke').returns(BbPromise.resolve());
+      sandbox
+        .stub(slsw, 'prepareStepOfflineInvoke')
+        .returns(BbPromise.resolve());
     });
 
     beforeEach(() => {
@@ -128,287 +146,351 @@ describe('ServerlessWebpack', () => {
       slsw.cleanup.restore();
     });
 
-    _.forEach([
-      {
-        name: 'before:package:createDeploymentArtifacts',
-        test: () => {
-          it('should spawn validate, compile and package', () => {
-            return expect(slsw.hooks['before:package:createDeploymentArtifacts']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledThrice;
-              expect(slsw.serverless.pluginManager.spawn.firstCall).to.have.been.calledWithExactly('webpack:validate');
-              expect(slsw.serverless.pluginManager.spawn.secondCall).to.have.been.calledWithExactly('webpack:compile');
-              expect(slsw.serverless.pluginManager.spawn.thirdCall).to.have.been.calledWithExactly('webpack:package');
-              return null;
+    _.forEach(
+      [
+        {
+          name: 'before:package:createDeploymentArtifacts',
+          test: () => {
+            it('should spawn validate, compile and package', () => {
+              return expect(
+                slsw.hooks['before:package:createDeploymentArtifacts'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.serverless.pluginManager.spawn).to.have.been
+                  .calledThrice;
+                expect(
+                  slsw.serverless.pluginManager.spawn.firstCall,
+                ).to.have.been.calledWithExactly('webpack:validate');
+                expect(
+                  slsw.serverless.pluginManager.spawn.secondCall,
+                ).to.have.been.calledWithExactly('webpack:compile');
+                expect(
+                  slsw.serverless.pluginManager.spawn.thirdCall,
+                ).to.have.been.calledWithExactly('webpack:package');
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'after:package:createDeploymentArtifacts',
-        test: () => {
-          it('should call cleanup', () => {
-            return expect(slsw.hooks['after:package:createDeploymentArtifacts']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.cleanup).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'after:package:createDeploymentArtifacts',
+          test: () => {
+            it('should call cleanup', () => {
+              return expect(
+                slsw.hooks['after:package:createDeploymentArtifacts'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.cleanup).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'before:deploy:function:packageFunction',
-        test: () => {
-          it('should spawn validate, compile and package', () => {
-            return expect(slsw.hooks['before:deploy:function:packageFunction']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledThrice;
-              expect(slsw.serverless.pluginManager.spawn.firstCall).to.have.been.calledWithExactly('webpack:validate');
-              expect(slsw.serverless.pluginManager.spawn.secondCall).to.have.been.calledWithExactly('webpack:compile');
-              expect(slsw.serverless.pluginManager.spawn.thirdCall).to.have.been.calledWithExactly('webpack:package');
-              return null;
+          },
+        },
+        {
+          name: 'before:deploy:function:packageFunction',
+          test: () => {
+            it('should spawn validate, compile and package', () => {
+              return expect(
+                slsw.hooks['before:deploy:function:packageFunction'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.serverless.pluginManager.spawn).to.have.been
+                  .calledThrice;
+                expect(
+                  slsw.serverless.pluginManager.spawn.firstCall,
+                ).to.have.been.calledWithExactly('webpack:validate');
+                expect(
+                  slsw.serverless.pluginManager.spawn.secondCall,
+                ).to.have.been.calledWithExactly('webpack:compile');
+                expect(
+                  slsw.serverless.pluginManager.spawn.thirdCall,
+                ).to.have.been.calledWithExactly('webpack:package');
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'webpack:webpack',
-        test: () => {
-          it('should spawn validate, compile and package', () => {
-            return expect(slsw.hooks['webpack:webpack']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledThrice;
-              expect(slsw.serverless.pluginManager.spawn.firstCall).to.have.been.calledWithExactly('webpack:validate');
-              expect(slsw.serverless.pluginManager.spawn.secondCall).to.have.been.calledWithExactly('webpack:compile');
-              expect(slsw.serverless.pluginManager.spawn.thirdCall).to.have.been.calledWithExactly('webpack:package');
-              return null;
+          },
+        },
+        {
+          name: 'webpack:webpack',
+          test: () => {
+            it('should spawn validate, compile and package', () => {
+              return expect(
+                slsw.hooks['webpack:webpack'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.serverless.pluginManager.spawn).to.have.been
+                  .calledThrice;
+                expect(
+                  slsw.serverless.pluginManager.spawn.firstCall,
+                ).to.have.been.calledWithExactly('webpack:validate');
+                expect(
+                  slsw.serverless.pluginManager.spawn.secondCall,
+                ).to.have.been.calledWithExactly('webpack:compile');
+                expect(
+                  slsw.serverless.pluginManager.spawn.thirdCall,
+                ).to.have.been.calledWithExactly('webpack:package');
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'before:invoke:local:invoke',
-        test: () => {
-          it('should prepare for local invoke', () => {
-            return expect(slsw.hooks['before:invoke:local:invoke']()).to.be.fulfilled
-            .then(() => {
-              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledTwice;
-              expect(slsw.serverless.pluginManager.spawn.firstCall).to.have.been.calledWithExactly('webpack:validate');
-              expect(slsw.serverless.pluginManager.spawn.secondCall).to.have.been.calledWithExactly('webpack:compile');
-              expect(slsw.prepareLocalInvoke).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'before:invoke:local:invoke',
+          test: () => {
+            it('should prepare for local invoke', () => {
+              return expect(
+                slsw.hooks['before:invoke:local:invoke'](),
+              ).to.be.fulfilled.then(() => {
+                expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+                expect(slsw.serverless.pluginManager.spawn).to.have.been
+                  .calledTwice;
+                expect(
+                  slsw.serverless.pluginManager.spawn.firstCall,
+                ).to.have.been.calledWithExactly('webpack:validate');
+                expect(
+                  slsw.serverless.pluginManager.spawn.secondCall,
+                ).to.have.been.calledWithExactly('webpack:compile');
+                expect(slsw.prepareLocalInvoke).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
 
-          it('should skip compile if requested', () => {
-            slsw.options.build = false;
-            return expect(slsw.hooks['before:invoke:local:invoke']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledOnce;
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledWithExactly('webpack:validate');
-              expect(slsw.prepareLocalInvoke).to.have.been.calledOnce;
-              return null;
+            it('should skip compile if requested', () => {
+              slsw.options.build = false;
+              return expect(
+                slsw.hooks['before:invoke:local:invoke'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.serverless.pluginManager.spawn).to.have.been
+                  .calledOnce;
+                expect(
+                  slsw.serverless.pluginManager.spawn,
+                ).to.have.been.calledWithExactly('webpack:validate');
+                expect(slsw.prepareLocalInvoke).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'after:invoke:local:invoke',
-        test: () => {
-          it('should return if watch is disabled', () => {
-            slsw.options.watch = false;
-            return expect(slsw.hooks['after:invoke:local:invoke']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.watch).to.not.have.been.called;
-              return null;
+          },
+        },
+        {
+          name: 'after:invoke:local:invoke',
+          test: () => {
+            it('should return if watch is disabled', () => {
+              slsw.options.watch = false;
+              return expect(
+                slsw.hooks['after:invoke:local:invoke'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.watch).to.not.have.been.called;
+                return null;
+              });
             });
-          });
 
-          it('should watch if enabled', () => {
-            slsw.options.watch = true;
-            return expect(slsw.hooks['after:invoke:local:invoke']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.watch).to.have.been.calledOnce;
-              expect(slsw.watch).to.have.been.calledWithExactly('invoke:local');
-              return null;
+            it('should watch if enabled', () => {
+              slsw.options.watch = true;
+              return expect(
+                slsw.hooks['after:invoke:local:invoke'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.watch).to.have.been.calledOnce;
+                expect(slsw.watch).to.have.been.calledWithExactly(
+                  'invoke:local',
+                );
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'before:run:run',
-        test: () => {
-          it('should prepare for run', () => {
-            return expect(slsw.hooks['before:run:run']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.serverless.service.package.individually).to.be.false;
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledTwice;
-              expect(slsw.serverless.pluginManager.spawn.firstCall).to.have.been.calledWithExactly('webpack:validate');
-              expect(slsw.serverless.pluginManager.spawn.secondCall).to.have.been.calledWithExactly('webpack:compile');
-              expect(slsw.packExternalModules).to.have.been.calledOnce;
-              expect(slsw.prepareRun).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'before:run:run',
+          test: () => {
+            it('should prepare for run', () => {
+              return expect(
+                slsw.hooks['before:run:run'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.serverless.service.package.individually).to.be
+                  .false;
+                expect(slsw.serverless.pluginManager.spawn).to.have.been
+                  .calledTwice;
+                expect(
+                  slsw.serverless.pluginManager.spawn.firstCall,
+                ).to.have.been.calledWithExactly('webpack:validate');
+                expect(
+                  slsw.serverless.pluginManager.spawn.secondCall,
+                ).to.have.been.calledWithExactly('webpack:compile');
+                expect(slsw.packExternalModules).to.have.been.calledOnce;
+                expect(slsw.prepareRun).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'after:run:run',
-        test: () => {
-          it('should return if watch is disabled', () => {
-            slsw.options.watch = false;
-            return expect(slsw.hooks['after:run:run']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.watch).to.not.have.been.called;
-              return null;
+          },
+        },
+        {
+          name: 'after:run:run',
+          test: () => {
+            it('should return if watch is disabled', () => {
+              slsw.options.watch = false;
+              return expect(slsw.hooks['after:run:run']()).to.be.fulfilled.then(
+                () => {
+                  expect(slsw.watch).to.not.have.been.called;
+                  return null;
+                },
+              );
             });
-          });
 
-          it('should watch if enabled', () => {
-            slsw.options.watch = true;
-            return expect(slsw.hooks['after:run:run']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.watch).to.have.been.calledOnce;
-              expect(slsw.watch).to.have.been.calledOnce;
-              return null;
+            it('should watch if enabled', () => {
+              slsw.options.watch = true;
+              return expect(slsw.hooks['after:run:run']()).to.be.fulfilled.then(
+                () => {
+                  expect(slsw.watch).to.have.been.calledOnce;
+                  expect(slsw.watch).to.have.been.calledOnce;
+                  return null;
+                },
+              );
             });
-          });
-        }
-      },
-      {
-        name: 'webpack:validate:validate',
-        test: () => {
-          it('should call validate', () => {
-            return expect(slsw.hooks['webpack:validate:validate']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.validate).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'webpack:validate:validate',
+          test: () => {
+            it('should call validate', () => {
+              return expect(
+                slsw.hooks['webpack:validate:validate'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.validate).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'webpack:compile:compile',
-        test: () => {
-          it('should call compile', () => {
-            return expect(slsw.hooks['webpack:compile:compile']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.compile).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'webpack:compile:compile',
+          test: () => {
+            it('should call compile', () => {
+              return expect(
+                slsw.hooks['webpack:compile:compile'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.compile).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'webpack:compile:watch:compile',
-        test: () => {
-          it('should resolve', () => {
-            return expect(slsw.hooks['webpack:compile:watch:compile']()).to.be.fulfilled;
-          });
-        }
-      },
-      {
-        name: 'webpack:package:packExternalModules',
-        test: () => {
-          it('should call packExternalModules', () => {
-            return expect(slsw.hooks['webpack:package:packExternalModules']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.packExternalModules).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'webpack:compile:watch:compile',
+          test: () => {
+            it('should resolve', () => {
+              return expect(slsw.hooks['webpack:compile:watch:compile']()).to.be
+                .fulfilled;
             });
-          });
-        }
-      },
-      {
-        name: 'webpack:package:packageModules',
-        test: () => {
-          it('should call packageModules', () => {
-            return expect(slsw.hooks['webpack:package:packageModules']()).to.be.fulfilled
-            .then(() => {
-              expect(slsw.packageModules).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'webpack:package:packExternalModules',
+          test: () => {
+            it('should call packExternalModules', () => {
+              return expect(
+                slsw.hooks['webpack:package:packExternalModules'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.packExternalModules).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'before:offline:start',
-        test: () => {
-          it('should prepare offline', () => {
-            slsw.options.build = true;
-            slsw.skipCompile = false;
-            return expect(slsw.hooks['before:offline:start']()).to.be.fulfilled
-            .then(() => {
-              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
-              expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
-              expect(slsw.wpwatch).to.have.been.calledOnce;
-              return null;
+          },
+        },
+        {
+          name: 'webpack:package:packageModules',
+          test: () => {
+            it('should call packageModules', () => {
+              return expect(
+                slsw.hooks['webpack:package:packageModules'](),
+              ).to.be.fulfilled.then(() => {
+                expect(slsw.packageModules).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-          it('should skip compiling when requested', () => {
-            slsw.skipCompile = false;
-            slsw.options.build = false;
-            return expect(slsw.hooks['before:offline:start']()).to.be.fulfilled
-            .then(() => {
-              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
-              expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
-              expect(slsw.wpwatch).to.not.have.been.called;
-              return null;
+          },
+        },
+        {
+          name: 'before:offline:start',
+          test: () => {
+            it('should prepare offline', () => {
+              slsw.options.build = true;
+              slsw.skipCompile = false;
+              return expect(
+                slsw.hooks['before:offline:start'](),
+              ).to.be.fulfilled.then(() => {
+                expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+                expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
+                expect(slsw.wpwatch).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'before:offline:start:init',
-        test: () => {
-          it('should prepare offline', () => {
-            slsw.skipCompile = false;
-            slsw.options.build = true;
-            return expect(slsw.hooks['before:offline:start:init']()).to.be.fulfilled
-            .then(() => {
-              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
-              expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
-              expect(slsw.wpwatch).to.have.been.calledOnce;
-              return null;
+            it('should skip compiling when requested', () => {
+              slsw.skipCompile = false;
+              slsw.options.build = false;
+              return expect(
+                slsw.hooks['before:offline:start'](),
+              ).to.be.fulfilled.then(() => {
+                expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+                expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
+                expect(slsw.wpwatch).to.not.have.been.called;
+                return null;
+              });
             });
-          });
-          it('should skip compiling when requested', () => {
-            slsw.skipCompile = false;
-            slsw.options.build = false;
-            return expect(slsw.hooks['before:offline:start:init']()).to.be.fulfilled
-            .then(() => {
-              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
-              expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
-              expect(slsw.wpwatch).to.not.have.been.called;
-              return null;
+          },
+        },
+        {
+          name: 'before:offline:start:init',
+          test: () => {
+            it('should prepare offline', () => {
+              slsw.skipCompile = false;
+              slsw.options.build = true;
+              return expect(
+                slsw.hooks['before:offline:start:init'](),
+              ).to.be.fulfilled.then(() => {
+                expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+                expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
+                expect(slsw.wpwatch).to.have.been.calledOnce;
+                return null;
+              });
             });
-          });
-        }
-      },
-      {
-        name: 'before:step-functions-offline:start',
-        test: () => {
-          it('should prepare offline', () => {
-            return expect(slsw.hooks['before:step-functions-offline:start']()).to.be.fulfilled
-            .then(() => {
-              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
-              expect(slsw.prepareStepOfflineInvoke).to.have.been.calledOnce;
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledOnce;
-              expect(slsw.serverless.pluginManager.spawn).to.have.been.calledWithExactly('webpack:compile');
-              return null;
+            it('should skip compiling when requested', () => {
+              slsw.skipCompile = false;
+              slsw.options.build = false;
+              return expect(
+                slsw.hooks['before:offline:start:init'](),
+              ).to.be.fulfilled.then(() => {
+                expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+                expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
+                expect(slsw.wpwatch).to.not.have.been.called;
+                return null;
+              });
             });
-          });
-        }
-      },
-    ], hook => {
-      it(`should expose hook ${hook.name}`, () => {
-        expect(slsw).to.have.a.nested.property(`hooks.${hook.name}`);
-      });
+          },
+        },
+        {
+          name: 'before:step-functions-offline:start',
+          test: () => {
+            it('should prepare offline', () => {
+              return expect(
+                slsw.hooks['before:step-functions-offline:start'](),
+              ).to.be.fulfilled.then(() => {
+                expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+                expect(slsw.prepareStepOfflineInvoke).to.have.been.calledOnce;
+                expect(slsw.serverless.pluginManager.spawn).to.have.been
+                  .calledOnce;
+                expect(
+                  slsw.serverless.pluginManager.spawn,
+                ).to.have.been.calledWithExactly('webpack:compile');
+                return null;
+              });
+            });
+          },
+        },
+      ],
+      (hook) => {
+        it(`should expose hook ${hook.name}`, () => {
+          expect(slsw).to.have.a.nested.property(`hooks.${hook.name}`);
+        });
 
-      describe(hook.name, () => {
-        hook.test();
-      });
-    });
+        describe(hook.name, () => {
+          hook.test();
+        });
+      },
+    );
   });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -103,7 +103,7 @@ describe('ServerlessWebpack', () => {
 
   describe('hooks', () => {
     let slsw;
-  
+
     before(() => {
       slsw = new ServerlessWebpack(serverless, {});
       sandbox.stub(slsw, 'cleanup').returns(BbPromise.resolve());
@@ -336,11 +336,24 @@ describe('ServerlessWebpack', () => {
         name: 'before:offline:start',
         test: () => {
           it('should prepare offline', () => {
+            slsw.options.build = true;
+            slsw.skipCompile = false;
             return expect(slsw.hooks['before:offline:start']()).to.be.fulfilled
             .then(() => {
               expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
               expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
               expect(slsw.wpwatch).to.have.been.calledOnce;
+              return null;
+            });
+          });
+          it('should skip compiling when requested', () => {
+            slsw.skipCompile = false;
+            slsw.options.build = false;
+            return expect(slsw.hooks['before:offline:start']()).to.be.fulfilled
+            .then(() => {
+              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+              expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
+              expect(slsw.wpwatch).to.not.have.been.called;
               return null;
             });
           });
@@ -350,11 +363,24 @@ describe('ServerlessWebpack', () => {
         name: 'before:offline:start:init',
         test: () => {
           it('should prepare offline', () => {
+            slsw.skipCompile = false;
+            slsw.options.build = true;
             return expect(slsw.hooks['before:offline:start:init']()).to.be.fulfilled
             .then(() => {
               expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
               expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
               expect(slsw.wpwatch).to.have.been.calledOnce;
+              return null;
+            });
+          });
+          it('should skip compiling when requested', () => {
+            slsw.skipCompile = false;
+            slsw.options.build = false;
+            return expect(slsw.hooks['before:offline:start:init']()).to.be.fulfilled
+            .then(() => {
+              expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;
+              expect(slsw.prepareOfflineInvoke).to.have.been.calledOnce;
+              expect(slsw.wpwatch).to.not.have.been.called;
               return null;
             });
           });
@@ -379,7 +405,7 @@ describe('ServerlessWebpack', () => {
       it(`should expose hook ${hook.name}`, () => {
         expect(slsw).to.have.a.nested.property(`hooks.${hook.name}`);
       });
-  
+
       describe(hook.name, () => {
         hook.test();
       });


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Extends the --no-build option to `serverless offline start` and `serverless offline`, allowing the ability to use previously compiled files from either a previous `serverless offline start` (when keeping output files) or from a direct `serverless webpack`

Closes #415 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

skips wpwatch and sets skipCompile to true when --no-build is set in the CLI.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

added 2 tests to verify `serverless offline start --no-build` doesn't compile output again.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
