### PR TITLE
default webpackConfig.node should be false

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -141,6 +141,11 @@ module.exports = {
           filename: '[name].js',
         };
       }
+      
+      // Default node
+      if (!this.webpackConfig.node || _.isEmpty(this.webpackConfig.node)) {
+        this.webpackConfig.node = false;
+      }
 
       // Custom output path
       if (this.options.out) {

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -224,7 +224,7 @@ describe('validate', () => {
       return module
         .validate()
         .then(() => expect(module.webpackConfig.node).to.eql(false));
-    })
+    });
   });
 
   describe('config file load', () => {

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -894,3 +894,4 @@ describe('validate', () => {
     });
   });
 });
+

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -221,6 +221,21 @@ describe('validate', () => {
     });
   });
 
+  describe('default node', () => {
+    it('should turn NodeStuffPlugin and NodeSourcePlugin plugins off by default', () => {
+      const testEntry = 'testentry';
+      const testConfig = {
+        entry: testEntry,
+      };
+      const testServicePath = 'testpath';
+      module.serverless.config.servicePath = testServicePath;
+      _.set(module.serverless.service, 'custom.webpack.config', testConfig);
+      return module
+        .validate()
+        .then(() => expect(module.webpackConfig.node).to.eql(false));
+    })
+  });
+
   describe('config file load', () => {
     it('should load a webpack config from file if `custom.webpack` is a string', () => {
       const testConfig = 'testconfig';


### PR DESCRIPTION
completely turn off the NodeStuffPlugin and NodeSourcePlugin plugins.

We don't want webpack to mock node globals

See https://codeburst.io/use-webpack-with-dirname-correctly-4cad3b265a92 and https://webpack.js.org/configuration/node

<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
