### PR TITLE
Prepare release - 5.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,9 @@ me to take it over and continue working on the project. That helped to revive it
 ## Release Notes
 
 * 5.3.1
-
+  * Fixed bug that prevented to use handlers using import [#505][link-505]
+  * Do not print empty lines in webpack stats [#499][link-499]
+  * Added git hooks to improved code quality and developer experience [#496][link-496]
 
 * 5.3.0
   * Restore compatibility with TypeScript [#449][link-449] [#465][link-465]
@@ -1031,3 +1033,7 @@ me to take it over and continue working on the project. That helped to revive it
 [link-433]: https://github.com/serverless-heaven/serverless-webpack/issues/433
 [link-471]: https://github.com/serverless-heaven/serverless-webpack/issues/471
 [link-472]: https://github.com/serverless-heaven/serverless-webpack/pull/472
+
+[link-505]: https://github.com/serverless-heaven/serverless-webpack/issues/505
+[link-499]: https://github.com/serverless-heaven/serverless-webpack/issues/499
+[link-496]: https://github.com/serverless-heaven/serverless-webpack/pull/496

--- a/README.md
+++ b/README.md
@@ -756,6 +756,9 @@ me to take it over and continue working on the project. That helped to revive it
 
 ## Release Notes
 
+* 5.3.1
+
+
 * 5.3.0
   * Restore compatibility with TypeScript [#449][link-449] [#465][link-465]
   * Allow glob for excludeFiles [#471][link-471]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "author": "Frank Schmid <fschmid740@googlemail.com>",


### PR DESCRIPTION
## Release notes

* Fixed bug that prevented to use handlers using import [#505][link-505]
* Do not print empty lines in webpack stats [#499][link-499]
* Added git hooks to improved code quality and developer experience [#496][link-496]

[link-505]: https://github.com/serverless-heaven/serverless-webpack/issues/505
[link-499]: https://github.com/serverless-heaven/serverless-webpack/issues/499
[link-496]: https://github.com/serverless-heaven/serverless-webpack/pull/496
