### PR TITLE
Serialized compile to address #299

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,15 @@ if you are trying to override the entry in webpack.config.js with other unsuppor
 The individual packaging needs more time at the packaging phase, but you'll
 get that paid back twice at runtime.
 
+#### Individual packaging serializedCompile
+```yaml
+# serverless.yml
+custom:
+  webpack:
+    serializedCompile: true
+```
+Will run each webpack build one at a time which helps reduce memory usage and in some cases impoves overall build performance.
+
 ## Usage
 
 ### Automatic bundling

--- a/README.md
+++ b/README.md
@@ -1046,3 +1046,4 @@ me to take it over and continue working on the project. That helped to revive it
 [link-505]: https://github.com/serverless-heaven/serverless-webpack/issues/505
 [link-499]: https://github.com/serverless-heaven/serverless-webpack/issues/499
 [link-496]: https://github.com/serverless-heaven/serverless-webpack/pull/496
+

--- a/README.md
+++ b/README.md
@@ -1046,4 +1046,3 @@ me to take it over and continue working on the project. That helped to revive it
 [link-505]: https://github.com/serverless-heaven/serverless-webpack/issues/505
 [link-499]: https://github.com/serverless-heaven/serverless-webpack/issues/499
 [link-496]: https://github.com/serverless-heaven/serverless-webpack/pull/496
-

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -14,7 +14,8 @@ const DefaultConfig = {
   packager: 'npm',
   packagerOptions: {},
   keepOutputDirectory: false,
-  config: null
+  config: null,
+  serializedCompile: false
 };
 
 class Configuration {
@@ -71,6 +72,10 @@ class Configuration {
 
   get keepOutputDirectory() {
     return this._config.keepOutputDirectory;
+  }
+
+  get serializedCompile() {
+    return this._config.serializedCompile;
   }
 
   toJSON() {

--- a/lib/Configuration.test.js
+++ b/lib/Configuration.test.js
@@ -19,7 +19,8 @@ describe('Configuration', () => {
         packager: 'npm',
         packagerOptions: {},
         keepOutputDirectory: false,
-        config: null
+        config: null,
+        serializedCompile: false
       };
     });
 
@@ -78,7 +79,8 @@ describe('Configuration', () => {
         packager: 'npm',
         packagerOptions: {},
         keepOutputDirectory: false,
-        config: null
+        config: null,
+        serializedCompile: false
       });
     });
   });
@@ -98,7 +100,8 @@ describe('Configuration', () => {
         packager: 'npm',
         packagerOptions: {},
         keepOutputDirectory: false,
-        config: null
+        config: null,
+        serializedCompile: false
       });
     });
 
@@ -117,7 +120,8 @@ describe('Configuration', () => {
         packager: 'npm',
         packagerOptions: {},
         keepOutputDirectory: false,
-        config: null
+        config: null,
+        serializedCompile: false
       });
     });
   });

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,44 +5,57 @@ const BbPromise = require('bluebird');
 const webpack = require('webpack');
 const tty = require('tty');
 
+const defaultStatsConfig = {
+  colors: tty.isatty(process.stdout.fd),
+  hash: false,
+  version: false,
+  chunks: false,
+  children: false
+};
+
+function ensureArray(obj) {
+  return _.isArray(obj) ? obj : [obj];
+}
+
+function getStatsLogger(statsConfig, consoleLog) {
+  return stats => consoleLog(stats.toString(statsConfig || defaultStatsConfig));
+}
+
+function webpackCompile(config, logStats) {
+  return BbPromise
+    .fromCallback(cb => webpack(config).run(cb))
+    .then(stats => {
+      // ensure stats in any array in the case of multiCompile
+      stats = stats.stats ? stats.stats : [stats];
+
+      _.forEach(stats, compileStats => {
+        logStats(compileStats);
+        if (compileStats.hasErrors()) {
+          throw new Error('Webpack compilation error, see stats above');
+        }
+      });
+
+      return stats;
+    });
+}
+
+function webpackCompileSerial(configs, logStats) {
+  return BbPromise
+    .mapSeries(configs, config => webpackCompile(config, logStats))
+    .then(stats => _.flatten(stats));
+}
+
 module.exports = {
   compile() {
     this.serverless.cli.log('Bundling with Webpack...');
 
-    const compiler = webpack(this.webpackConfig);
+    const configs = ensureArray(this.webpackConfig);
+    const logStats = getStatsLogger(configs[0].stats, this.serverless.cli.consoleLog);
 
-    return BbPromise.fromCallback(cb => compiler.run(cb)).then(stats => {
-      if (!this.multiCompile) {
-        stats = { stats: [stats] };
-      }
-
-      const compileOutputPaths = [];
-      const consoleStats = this.webpackConfig.stats ||
-        _.get(this, 'webpackConfig[0].stats') || {
-        colors: tty.isatty(process.stdout.fd),
-        hash: false,
-        version: false,
-        chunks: false,
-        children: false
-      };
-
-      _.forEach(stats.stats, compileStats => {
-        const statsOutput = compileStats.toString(consoleStats);
-        if (statsOutput) {
-          this.serverless.cli.consoleLog(statsOutput);
-        }
-
-        if (compileStats.compilation.errors.length) {
-          throw new Error('Webpack compilation error, see above');
-        }
-
-        compileOutputPaths.push(compileStats.compilation.compiler.outputPath);
+    return (this.serializedCompile ? webpackCompileSerial : webpackCompile)(configs, logStats)
+      .then(stats => {
+        this.compileStats = { stats };
+        return BbPromise.resolve();
       });
-
-      this.compileOutputPaths = compileOutputPaths;
-      this.compileStats = stats;
-
-      return BbPromise.resolve();
-    });
   }
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -167,8 +167,9 @@ module.exports = {
 
       // In case of individual packaging we have to create a separate config for each function
       if (_.has(this.serverless, 'service.package') && this.serverless.service.package.individually) {
-        this.options.verbose && this.serverless.cli.log('Using multi-compile (individual packaging)');
         this.multiCompile = true;
+        this.serializedCompile = this.configuration.serializedCompile;
+        this.options.verbose && this.serverless.cli.log(`Using ${this.serializedCompile ? 'serialized' : 'multi'}-compile (individual packaging)`);
 
         if (this.webpackConfig.entry && !_.isEqual(this.webpackConfig.entry, entries)) {
           return BbPromise.reject(

--- a/tests/webpack.mock.js
+++ b/tests/webpack.mock.js
@@ -6,11 +6,15 @@ const StatsMock = () => ({
   compilation: {
     errors: [],
     compiler: {
-      outputPath: 'statsMock-outputPath'
-    }
+      outputPath: 'statsMock-outputPath',
+    },
   },
-  toString: sinon.stub().returns('testStats')
+  toString: sinon.stub().returns('testStats'),
+  hasErrors() {
+    return Boolean(this.compilation.errors.length);
+  },
 });
+
 
 const CompilerMock = (sandbox, statsMock) => ({
   run: sandbox.stub().yields(null, statsMock),
@@ -19,7 +23,7 @@ const CompilerMock = (sandbox, statsMock) => ({
     beforeCompile: {
       tapPromise: sandbox.stub()
     }
-  }
+  },
 });
 
 const webpackMock = sandbox => {


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Add the option to serialize webpack compilation when packaging individually. This addresses concerns in #299 and improves compilation speed significantly. In our project with 25 function this decreased the build time from ~400s to ~265s when run with the following command:
```
time node --max-old-space-size=4096 node_modules/.bin/sls package --verbose
```
While using `thread-loader` + `cache-loader` might be able to optimize accross the multiple builds it takes significant effort to get to a performant build. Running the webpack compilation in series appears to have better performance out of the box, so much so that I suggest it be the default behavior of this plugin. This PR maintains the existing multi-compile as the default and uses `custom.webpack.serializedCompile` to enable the serial build.

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:
Modified `compile.js` to use `BbPromise.mapSeries` instead of webpack's multi-compiler functionality. This cut down
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Set `custom.webpack.serializedCompile` to `true` in `serverless.yml` and run the following command:
```
time node --max-old-space-size=4096 node_modules/.bin/sls package --verbose
```
Now set the `custom.webpack.serializedCompile` to `false` or omit the option entirely to revert to the default behavior and run the same command. Verify that both compile successfully and observe a significant speed improvement when a project with many functions is serialized.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
