### PR TITLE
Options to control which functions will be build with webpack and whi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,41 @@ custom:
 
 This is also useful for projects that use TypeScript.
 
+#### Exclude functions from the Webpack build
+
+By default, serverless-webpack assumes that all the functions defined in the template can and will be built using Webpack.
+This is not always the case, as serverless supports multi-language stacks, where some of the functions can be implemented in other languages, like C# or Python or Go.
+To control which functions should the plugin build, you can use configuration settions:
+
+```yaml
+# serverless.yml
+custom:
+  webpack:
+    # This is useful when all your functions except some are in JS or TS
+    excludeFunctions:
+      - myPythonFunction1
+      - myCSharpFunction1
+```
+
+```yaml
+# serverless.yml
+custom:
+  webpack:
+    # This is useful when your project is mostly in another language, but you have some JS functions
+    includeFunctions:
+      - myJsFunction1
+      - myJsFunction2
+```
+
+Alternatively, you can just provide a list of functions to build in the command line options:
+
+```bash
+$ serverless webpack --function myJsFunction1 --function myJsFunction2
+```
+
+If you provide the list of functions in the command line options, the configuration file settings are ignored, so make sure to include
+all your functions in the command line options should you decide to follow that path.
+
 #### Keep output directory after packaging
 
 You can keep the output directory (defaults to `.webpack`) from being removed

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -73,6 +73,14 @@ class Configuration {
     return this._config.keepOutputDirectory;
   }
 
+  get includeFunctions() {
+    return this._config.includeFunctions;
+  }
+
+  get excludeFunctions() {
+    return this._config.excludeFunctions;
+  }
+
   toJSON() {
     return _.omitBy(this._config, _.isNil);
   }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -74,6 +74,19 @@ module.exports = {
       };
     };
 
+    const getFunctions = () => {
+      if (this.options.function) {
+        return _.castArray(this.options.function);
+      }
+      const excludedFunctions = this.configuration.excludeFunctions
+        ? _.castArray(this.configuration.excludeFunctions)
+        : [];
+      const includedFunctions = this.configuration.includeFunctions
+        ? _.castArray(this.configuration.includeFunctions)
+        : this.serverless.service.getAllFunctions();
+      return _.difference(includedFunctions, excludedFunctions);
+    };
+
     // Initialize plugin configuration
     this.configuration = new Configuration(this.serverless.service.custom);
     this.options.verbose &&
@@ -89,17 +102,11 @@ module.exports = {
     // Expose entries - must be done before requiring the webpack configuration
     const entries = {};
 
-    const functions = this.serverless.service.getAllFunctions();
-    if (this.options.function) {
-      const serverlessFunction = this.serverless.service.getFunction(this.options.function);
-      const entry = getEntryForFunction.call(this, this.options.function, serverlessFunction);
+    const functions = getFunctions();
+    _.forEach(functions, (func, index) => {
+      const entry = getEntryForFunction.call(this, functions[index], this.serverless.service.getFunction(func));
       _.merge(entries, entry);
-    } else {
-      _.forEach(functions, (func, index) => {
-        const entry = getEntryForFunction.call(this, functions[index], this.serverless.service.getFunction(func));
-        _.merge(entries, entry);
-      });
-    }
+    });
 
     // Expose service file and options
     lib.serverless = this.serverless;


### PR DESCRIPTION
…ch will not

closes #255

<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #255

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I've added the configuration options to include and exclude functions that will be built using Webpack; made the `--function` option support multiple entries.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

* Create a serverless-webpack configuration with three functions
* Add one of those functions under custom / webpack / excludeFunctions, make sure Webpack does not try to build that function
* Add one of those functions under custom / webpack / includeFunctions, make sure Webpack does not try to build functions other than that
* Run `serverless webpack --function func1 --function func2`, make sure only Webpack only tries to build `func1` and `func2`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
