### PR TITLE
Fix external modules version for transitive dependencies

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -130,6 +130,10 @@ function getProdModules(externalModules, packagePath, dependencyGraph, forceExcl
         const originInfo = _.get(dependencyGraph, 'dependencies', {})[module.origin] || {};
         moduleVersion = _.get(_.get(originInfo, 'dependencies', {})[module.external], 'version');
         if (!moduleVersion) {
+          // eslint-disable-next-line lodash/path-style 
+          moduleVersion = _.get(dependencyGraph, [ 'dependencies', module.external, 'version' ]);
+        }
+        if (!moduleVersion) {
           this.serverless.cli.log(`WARNING: Could not determine version of module ${module.external}`);
         }
         prodModules.push(moduleVersion ? `${module.external}@${moduleVersion}` : module.external);

--- a/tests/data/package-transitive.json
+++ b/tests/data/package-transitive.json
@@ -1,0 +1,22 @@
+{
+  "name": "comp-a",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "comp-b": "file:../comp-b",
+    "comp-c": "file:../comp-c"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "serverless": "^1.53.0",
+    "serverless-webpack": "^5.3.1",
+    "webpack": "^4.41.0",
+    "webpack-node-externals": "^1.7.2"
+  }
+}


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

**This pull request is the same change as #507** plus tests added. I also published a repo with a minimal reproduction case: https://github.com/salomvary/serverless-webpack-bug/tree/master/comp-a (run `yarn && node_modules/.bin/serverless package`).

## What did you implement:

Same as in #507.

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Same as in #507.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Same as in #507.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
