### PR TITLE
Move `ts-node` as optional dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,11 @@ class ServerlessWebpack {
       (_.has(this.serverless, 'service.custom.webpack.webpackConfig') &&
         _.endsWith(this.serverless.service.custom.webpack.webpackConfig, '.ts'))
     ) {
-      require('ts-node/register');
+      try {
+        require('ts-node/register');
+      } catch (e) {
+        throw new Error('If you want to use TypeScript with serverless-webpack, please add "ts-node" as dependency.');
+      }
     }
 
     _.assign(

--- a/index.test.js
+++ b/index.test.js
@@ -20,6 +20,7 @@ describe('ServerlessWebpack', () => {
   let sandbox;
   let serverless;
   let ServerlessWebpack;
+  let moduleStub;
 
   before(function() {
     // Mockery might take some time to clear the cache. So add 3 seconds to the default timeout.
@@ -32,7 +33,7 @@ describe('ServerlessWebpack', () => {
     mockery.registerMock('webpack', {});
 
     ServerlessWebpack = require('./index');
-    sandbox.spy(Module, '_load');
+    moduleStub = sandbox.stub(Module, '_load');
   });
 
   beforeEach(() => {
@@ -82,6 +83,25 @@ describe('ServerlessWebpack', () => {
       new ServerlessWebpack(serverless, {});
       expect(Module._load).to.have.been.calledOnce;
       expect(Module._load).to.have.been.calledWith('ts-node/register');
+    });
+
+    it('should throw an error if config use TS but ts-node was not added as dependency', () => {
+      moduleStub.throws();
+
+      _.set(serverless, 'service.custom.webpack.webpackConfig', 'webpack.config.ts');
+
+      const badDeps = function() {
+        new ServerlessWebpack(serverless, {});
+      };
+
+      expect(badDeps).to.throw(
+        'If you want to use TypeScript with serverless-webpack, please add "ts-node" as dependency.'
+      );
+
+      expect(Module._load).to.have.been.calledOnce;
+      expect(Module._load).to.have.been.calledWith('ts-node/register');
+
+      moduleStub.reset();
     });
   });
 

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -442,4 +442,3 @@ module.exports = {
     });
   }
 };
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -656,7 +656,8 @@
     "arg": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw=="
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "optional": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2178,7 +2179,8 @@
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+      "optional": true
     },
     "dlv": {
       "version": "1.1.3",
@@ -4984,7 +4986,8 @@
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "optional": true
     },
     "make-plural": {
       "version": "4.3.0",
@@ -8274,6 +8277,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
       "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "optional": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -8998,7 +9002,8 @@
     "yn": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
-      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg=="
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+      "optional": true
     },
     "zip-stream": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "glob": "^7.1.4",
     "is-builtin-module": "^3.0.0",
     "lodash": "^4.17.19",
-    "semver": "^6.2.0",
-    "ts-node": "^8.3.0"
+    "semver": "^6.2.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.2",
@@ -80,5 +79,8 @@
   },
   "peerDependencies": {
     "webpack": ">= 3.0.0 < 6"
+  },
+  "optionalDependencies": {
+    "ts-node": ">= 8.3.0"
   }
 }

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -216,14 +216,12 @@ describe('validate', () => {
     it('should turn NodeStuffPlugin and NodeSourcePlugin plugins off by default', () => {
       const testEntry = 'testentry';
       const testConfig = {
-        entry: testEntry,
+        entry: testEntry
       };
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
       _.set(module.serverless.service, 'custom.webpack.config', testConfig);
-      return module
-        .validate()
-        .then(() => expect(module.webpackConfig.node).to.eql(false));
+      return module.validate().then(() => expect(module.webpackConfig.node).to.eql(false));
     });
   });
 
@@ -913,4 +911,3 @@ describe('validate', () => {
     });
   });
 });
-


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #633

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

`ts-node` dependency must be added by the user only if they use TypeScript.

## How can we verify it:

An error will be throw if the dependency is not added and the serverless-webpack configuration is written in TypeScript.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
