### PR TITLE
Support noFrozenLockfile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,10 @@ Using yarn will switch the whole packaging pipeline to use yarn, so does it use 
 
 The yarn packager supports the following `packagerOptions`:
 
-| Option        | Type | Default | Description |
-|---------------|------|---------|-------------|
-| ignoreScripts | bool | true    | Do not execute package.json hook scripts on install |
+| Option           | Type | Default  | Description                                         |
+|------------------|------|----------|-----------------------------------------------------|
+| ignoreScripts    | bool | false    | Do not execute package.json hook scripts on install |
+| noFrozenLockfile | bool | false    | Do not require an up-to-date yarn.lock              |
 
 ##### Common packager options
 

--- a/lib/packagers/yarn.js
+++ b/lib/packagers/yarn.js
@@ -5,6 +5,7 @@
  * Yarn specific packagerOptions (default):
  *   flat (false) - Use --flat with install
  *   ignoreScripts (false) - Do not execute scripts during install
+ *   noFrozenLockfile (false) - Do not require an up-to-date yarn.lock
  */
 
 const _ = require('lodash');
@@ -117,9 +118,12 @@ class Yarn {
 
   static install(cwd, packagerOptions) {
     const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
-    const args = [ 'install', '--frozen-lockfile', '--non-interactive' ];
+    const args = [ 'install', '--non-interactive' ];
 
     // Convert supported packagerOptions
+    if (!packagerOptions.noFrozenLockfile) {
+      args.push('--frozen-lockfile');
+    }
     if (packagerOptions.ignoreScripts) {
       args.push('--ignore-scripts');
     }

--- a/lib/packagers/yarn.test.js
+++ b/lib/packagers/yarn.test.js
@@ -218,7 +218,7 @@ describe('yarn', () => {
         expect(Utils.spawnProcess).to.have.been.calledOnce;
         expect(Utils.spawnProcess).to.have.been.calledWithExactly(
           sinon.match(/^yarn/),
-          [ 'install', '--frozen-lockfile', '--non-interactive' ],
+          [ 'install', '--non-interactive', '--frozen-lockfile' ],
           {
             cwd: 'myPath'
           }
@@ -234,7 +234,23 @@ describe('yarn', () => {
         expect(Utils.spawnProcess).to.have.been.calledOnce;
         expect(Utils.spawnProcess).to.have.been.calledWithExactly(
           sinon.match(/^yarn/),
-          [ 'install', '--frozen-lockfile', '--non-interactive', '--ignore-scripts' ],
+          [ 'install', '--non-interactive', '--frozen-lockfile', '--ignore-scripts' ],
+          {
+            cwd: 'myPath'
+          }
+        );
+        return null;
+      });
+    });
+
+    it('should use noFrozenLockfile option', () => {
+      Utils.spawnProcess.returns(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(yarnModule.install('myPath', { noFrozenLockfile: true })).to.be.fulfilled.then(result => {
+        expect(result).to.be.undefined;
+        expect(Utils.spawnProcess).to.have.been.calledOnce;
+        expect(Utils.spawnProcess).to.have.been.calledWithExactly(
+          sinon.match(/^yarn/),
+          [ 'install', '--non-interactive' ],
           {
             cwd: 'myPath'
           }


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

We have a monorepo with several serverless packages. Given the way we do CI and the way `lerna` deals with lockfiles, we actually don't need and don't have an up to date `yarn.lock`, but for our usecase it doesn't really matter.

This adds the option `noFrozenLockfile` to `packagerOptions`, allowing to run `yarn install` without the `--no-frozen-lockfile` option. This is as suggested in this comment https://github.com/serverless-heaven/serverless-webpack/issues/369#issuecomment-381519788 

I also fixed the documentation for `ignoreScripts` in the README, which mentioned a default value of `true` when it is in fact `false`

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

Added the option in the `install` function in `yarn.js`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

I added tests to make sure the option was omitted when using `noFrozenLockfile`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
