### PR TITLE
Don't package non-node functions (fix for #644)

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -191,7 +191,10 @@ module.exports = {
       if (_.has(this.serverless, 'service.package') && this.serverless.service.package.individually) {
         this.multiCompile = true;
         this.serializedCompile = this.configuration.serializedCompile;
-        this.options.verbose && this.serverless.cli.log(`Using ${this.serializedCompile ? 'serialized' : 'multi'}-compile (individual packaging)`);
+        this.options.verbose &&
+          this.serverless.cli.log(
+            `Using ${this.serializedCompile ? 'serialized' : 'multi'}-compile (individual packaging)`
+          );
 
         if (this.webpackConfig.entry && !_.isEqual(this.webpackConfig.entry, entries)) {
           return BbPromise.reject(
@@ -203,16 +206,23 @@ module.exports = {
         }
 
         // Lookup associated Serverless functions
-        const allEntryFunctions = _.map(this.serverless.service.getAllFunctions(), funcName => {
-          const func = this.serverless.service.getFunction(funcName);
-          const handler = func.handler;
-          const handlerFile = path.relative('.', getHandlerFile(handler));
-          return {
-            handlerFile,
-            funcName,
-            func
-          };
-        });
+        const allEntryFunctions = _.map(
+          _.filter(this.serverless.service.getAllFunctions(), funcName => {
+            const func = this.serverless.service.getFunction(funcName);
+            const runtime = func.runtime || this.serverless.service.provider.runtime || 'nodejs';
+            return runtime.match(/node/);
+          }),
+          funcName => {
+            const func = this.serverless.service.getFunction(funcName);
+            const handler = func.handler;
+            const handlerFile = path.relative('.', getHandlerFile(handler));
+            return {
+              handlerFile,
+              funcName,
+              func
+            };
+          }
+        );
 
         this.entryFunctions = _.flatMap(entries, (value, key) => {
           const entry = path.relative('.', value);

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -468,6 +468,18 @@ describe('validate', () => {
             }
           ],
           runtime: 'java8'
+        },
+        rustfunc: {
+          handler: 'my-rust-func',
+          runtime: 'rust',
+          events: [
+            {
+              http: {
+                method: 'POST',
+                path: 'rustfuncpath'
+              }
+            }
+          ]
         }
       };
 
@@ -960,7 +972,7 @@ describe('validate', () => {
   });
 
   describe('with skipped builds', () => {
-    it('should set `skipComile` to true if `options.build` is false', () => {
+    it('should set `skipCompile` to true if `options.build` is false', () => {
       const testConfig = {
         entry: 'test',
         output: {}


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Most of serverless-webpack already deals with not packaging non-node functions. There is only one section that is still problematic. This fix deals with the issue where a runtime may be defined for an individual function or for a provider. It will default to a runtime of "nodejs" if no runtime is specified at either the function or provider level.

Closes #644 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

When processing the async config, implemented an extra step before mapping the functions to filter out functions that don't have a node runtime.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Add a function (in my case it was a Rust function) that uses a non-node runtime and the app should still package correctly.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
