### PR TITLE
Update CHANGELOG for 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Change Log
 
 * 5.4.0
-  * Skip compile & packaging if --no-build is set [#560](https://github.com/serverless-heaven/serverless-webpack/pull/560)
+  * Skip compile & packaging if `--no-build` is set [#560](https://github.com/serverless-heaven/serverless-webpack/pull/560)
   * Serialized compile to address [#299](https://github.com/serverless-heaven/serverless-webpack/pull/299) [#517](https://github.com/serverless-heaven/serverless-webpack/pull/517)
+  * Add concurrency support for more than one thread [#681](https://github.com/serverless-heaven/serverless-webpack/pull/681)
   * Option to exclude files using regular expression [#612](https://github.com/serverless-heaven/serverless-webpack/pull/612)
   * Speed up cleanup process [#462](https://github.com/serverless-heaven/serverless-webpack/pull/462)
-  
+  * Allow custom runtime if Nodejs based [#675](https://github.com/serverless-heaven/serverless-webpack/pull/675)
+  * Convert packageModules to use bestzip instead of archiver [#596](https://github.com/serverless-heaven/serverless-webpack/pull/596)
+  * Fix external modules version for transitive dependencies [#541](https://github.com/serverless-heaven/serverless-webpack/pull/541) (see [#507](https://github.com/serverless-heaven/serverless-webpack/pull/507))
+  * Support noFrozenLockfile options [#687](https://github.com/serverless-heaven/serverless-webpack/pull/687)
+  * Don't package non-node functions (fix for [#644](https://github.com/serverless-heaven/serverless-webpack/issues/644)) [#663](https://github.com/serverless-heaven/serverless-webpack/pull/663)
+  * Testing with Node.js 14.x [#688](https://github.com/serverless-heaven/serverless-webpack/pull/688)
+
 * 5.3.5
   * Improve runtime validation [#629](https://github.com/serverless-heaven/serverless-webpack/pull/629)
   * Move `ts-node` as optional dependency [#636](https://github.com/serverless-heaven/serverless-webpack/pull/636)


### PR DESCRIPTION
It's been too long since the latest release and some PRs are too old to be part of the 5.4.0 release. So let's release it.
PR with the 5.4.0 milestone will be shipped in 5.5.0 or maybe 5.4.1, we'll later.

Here is a proposal for the text for the release:

```
New options:
- `noFrozenLockfile` (boolean) under the `packagerOptions` for the Yarn packager allows you to not have an up to date `yarn.lock`. See #687
- `excludeRegex` (string) allows you to filter files that match the regex before adding to the zip. See #612
- `serializedCompile` (boolean) allows you to run each webpack buid one at a time to reduce memory usage. See #517
- `allowCustomRuntime` (boolean) added to the function level in your `serverless.yml` allows you force the packaging when you are using a nodejs custom runtime ONLY. See #675
- `concurrency` (integer) allow to set the concurrency (defaults to the number of available cores), only works when packing functions individually. See #681 

New arguments:
- the `--no-build` used when deploying won't re-build everything if you already build it (using `sls webpack` for example). See #560

Optimizations:
- switched to `bestzip` instead of `archiver` to use natine zip command if it exists. See #596
- speed up cleanup process when removing `.webpack` folder. See #462
```