### PR TITLE
5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.3.5",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.3.5",
+  "version": "5.4.0",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Ok I forgot to run `npm version minor` before creating the release, so the npm publish failed (of course) because it tried to push the 5.3.5

https://github.com/serverless-heaven/serverless-webpack/runs/2128824681?check_suite_focus=true

🤦 