### PR TITLE
Display the zip method used

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -3,7 +3,7 @@
 const BbPromise = require('bluebird');
 const _ = require('lodash');
 const path = require('path');
-const bestzip = require('bestzip');
+const { bestzip, hasNativeZip } = require('bestzip');
 const glob = require('glob');
 const semver = require('semver');
 const fs = require('fs');
@@ -118,7 +118,7 @@ module.exports = {
           () =>
             this.options.verbose &&
             this.serverless.cli.log(
-              `Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'}: ${modulePath} [${_.now() - startZip} ms]`
+              `Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'} (using ${hasNativeZip() ? 'native' : 'node'} method): ${modulePath} [${_.now() - startZip} ms]`
             )
         );
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -967,24 +967,24 @@
       }
     },
     "@serverless/platform-sdk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-2.3.1.tgz",
-      "integrity": "sha512-EiSizya9bK0+5uae3GH9uXuWAchZplkLO0tWOAXtnU5QWSg5zicANL9jKCw0dyhjUOvbcO0ddhFlG8EGYvJFSA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-2.3.2.tgz",
+      "integrity": "sha512-JSX0/EphGVvnb4RAgZYewtBXPuVsU2TFCuXh6EEZ4jxK3WgUwNYeYdwB8EuVLrm1/dYqu/UWUC0rPKb+ZDycJg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "chalk": "^2.4.2",
         "https-proxy-agent": "^4.0.0",
         "is-docker": "^1.1.0",
-        "isomorphic-fetch": "^2.2.1",
         "jwt-decode": "^2.2.0",
+        "node-fetch": "^2.6.1",
         "opn": "^5.5.0",
         "querystring": "^0.2.0",
         "ramda": "^0.25.0",
         "rc": "^1.2.8",
-        "regenerator-runtime": "^0.13.1",
-        "source-map-support": "^0.5.12",
-        "uuid": "^3.3.2",
-        "write-file-atomic": "^2.4.2",
+        "regenerator-runtime": "^0.13.7",
+        "source-map-support": "^0.5.19",
+        "uuid": "^3.4.0",
+        "write-file-atomic": "^2.4.3",
         "ws": "<7.0.0"
       },
       "dependencies": {
@@ -1008,6 +1008,12 @@
           "version": "0.25.0",
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
           "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         },
         "ws": {
@@ -3458,26 +3464,6 @@
       "dev": true,
       "requires": {
         "env-variable": "0.0.x"
-      }
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
       }
     },
     "end-of-stream": {
@@ -6449,28 +6435,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "isomorphic-ws": {
       "version": "4.0.1",
@@ -11477,12 +11441,6 @@
           }
         }
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==",
-      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/tests/mocks/bestzip.mock.js
+++ b/tests/mocks/bestzip.mock.js
@@ -9,7 +9,8 @@ const sinon = require('sinon');
 const BestZipMock = sandbox => sandbox.stub();
 
 module.exports.create = sandbox => {
-  const bestzipMock = BestZipMock(sandbox);
-  const mock = sinon.stub().resolves(bestzipMock);
-  return mock;
+  return {
+    bestzip: sinon.stub().resolves(BestZipMock(sandbox)),
+    hasNativeZip: sandbox.stub().returns(false),
+  };
 };

--- a/tests/mocks/bestzip.mock.js
+++ b/tests/mocks/bestzip.mock.js
@@ -9,8 +9,13 @@ const sinon = require('sinon');
 const BestZipMock = sandbox => sandbox.stub();
 
 module.exports.create = sandbox => {
+  const hasNativeZip = sinon.stub();
+  hasNativeZip.onCall(0).returns(false);
+  hasNativeZip.onCall(1).returns(true);
+  hasNativeZip.returns(false);
+
   return {
     bestzip: sinon.stub().resolves(BestZipMock(sandbox)),
-    hasNativeZip: sandbox.stub().returns(false),
+    hasNativeZip,
   };
 };

--- a/tests/mocks/child_process.mock.js
+++ b/tests/mocks/child_process.mock.js
@@ -5,11 +5,9 @@
  */
 
 module.exports.create = sandbox => {
-  const childProcessMock = {
+  return {
     exec: sandbox.stub().yields(),
     spawn: sandbox.stub().returns(/* child process object */),
     execSync: sandbox.stub().returns('{}')
   };
-
-  return childProcessMock;
 };

--- a/tests/mocks/fs-extra.mock.js
+++ b/tests/mocks/fs-extra.mock.js
@@ -5,12 +5,10 @@
  */
 
 module.exports.create = sandbox => {
-  const fsExtraMock = {
+  return {
     copy: sandbox.stub().yields(),
     pathExists: sandbox.stub().yields(),
     pathExistsSync: sandbox.stub().returns(false),
     removeSync: sandbox.stub()
   };
-
-  return fsExtraMock;
 };

--- a/tests/mocks/fs.mock.js
+++ b/tests/mocks/fs.mock.js
@@ -18,7 +18,8 @@ const StatMock = sandbox => ({
 module.exports.create = sandbox => {
   const streamMock = StreamMock(sandbox);
   const statMock = StatMock(sandbox);
-  const fsMock = {
+
+  return {
     createWriteStream: sinon.stub().returns(streamMock), // Persistent stub
     readFileSync: sandbox.stub(),
     statSync: sinon.stub().returns(statMock), // Persistent stub
@@ -28,6 +29,4 @@ module.exports.create = sandbox => {
     _streamMock: streamMock,
     _statMock: statMock
   };
-
-  return fsMock;
 };

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -73,7 +73,9 @@ describe('packageModules', () => {
     module = _.assign(
       {
         serverless,
-        options: {},
+        options: {
+          verbose: true,
+        },
         webpackOutputPath: '.webpack',
         configuration: new Configuration()
       },

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -92,7 +92,7 @@ describe('packageModules', () => {
       module.compileStats = { stats: [] };
       return expect(module.packageModules()).to.be.fulfilled.then(() =>
         BbPromise.all([
-          expect(bestzipMock).to.not.have.been.called,
+          expect(bestzipMock.bestzip).to.not.have.been.called,
           expect(writeFileDirStub).to.not.have.been.called,
           expect(fsMock.createWriteStream).to.not.have.been.called,
           expect(globMock.sync).to.not.have.been.called
@@ -104,7 +104,7 @@ describe('packageModules', () => {
       module.skipCompile = true;
       return expect(module.packageModules()).to.be.fulfilled.then(() =>
         BbPromise.all([
-          expect(bestzipMock).to.not.have.been.called,
+          expect(bestzipMock.bestzip).to.not.have.been.called,
           expect(writeFileDirStub).to.not.have.been.called,
           expect(fsMock.createWriteStream).to.not.have.been.called,
           expect(globMock.sync).to.not.have.been.called


### PR DESCRIPTION
Since 5.4.0 we are using `bestzip` which can improve performance by using native `zip` method if available instead of the node one.
But we don't know which method is used during the build, so improving a small log to know that information.

```
Serverless: Zip service (using native zip method): /project/.webpack/service [11882 ms]
```

Also:
- run `npm audit fix` to fix some vulnerabilities.
- improve / cleanup return data from mocks
