### PR TITLE
Fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       time: "02:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
-    version_requirement_updates: increase_versions
+    versioning-strategy: increase
     ignore:
       - dependency-name: husky
         versions:


### PR DESCRIPTION
The validation failed: https://github.com/serverless-heaven/serverless-webpack/runs/2194219661

Sadly I read the wrong documentation ...
The good one is: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#versioning-strategy