### PR TITLE
Fix configuration check for keepoutputdirectory in cleanup

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -7,7 +7,7 @@ const fse = require('fs-extra');
 module.exports = {
   cleanup() {
     const webpackOutputPath = this.webpackOutputPath;
-    const keepOutputDirectory = this.keepOutputDirectory;
+    const keepOutputDirectory = this.keepOutputDirectory || this.configuration.keepOutputDirectory;
     const cli = this.options.verbose ? this.serverless.cli : { log: _.noop };
 
     if (!keepOutputDirectory) {

--- a/tests/cleanup.test.js
+++ b/tests/cleanup.test.js
@@ -6,6 +6,7 @@ const chai = require('chai');
 const sinon = require('sinon');
 const mockery = require('mockery');
 const Serverless = require('serverless');
+const Configuration = require('../lib/Configuration');
 
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
@@ -58,7 +59,8 @@ describe('cleanup', () => {
         options: {
           verbose: true
         },
-        webpackOutputPath: 'my/Output/Path'
+        webpackOutputPath: 'my/Output/Path',
+        configuration: new Configuration()
       },
       baseModule
     );
@@ -88,16 +90,7 @@ describe('cleanup', () => {
     dirExistsSyncStub.returns(true);
     fseMock.remove.resolves(true);
 
-    module = _.assign(
-      {
-        serverless,
-        options: {
-          verbose: false
-        },
-        webpackOutputPath: 'my/Output/Path'
-      },
-      baseModule
-    );
+    module = _.assign({}, module, { options: { verbose: false } });
 
     return expect(module.cleanup()).to.be.fulfilled.then(() => {
       expect(dirExistsSyncStub).to.have.been.calledOnce;
@@ -136,6 +129,20 @@ describe('cleanup', () => {
     const configuredModule = _.assign({}, module, {
       keepOutputDirectory: true
     });
+    return expect(configuredModule.cleanup()).to.be.fulfilled.then(() => {
+      expect(dirExistsSyncStub).to.not.have.been.calledOnce;
+      expect(fseMock.remove).to.not.have.been.called;
+      return null;
+    });
+  });
+
+  it('should keep output dir if keepOutputDir = true in configuration', () => {
+    dirExistsSyncStub.returns(true);
+
+    const configuredModule = _.assign({}, module, {
+      configuration: new Configuration({ webpack: { keepOutputDirectory: true } })
+    });
+
     return expect(configuredModule.cleanup()).to.be.fulfilled.then(() => {
       expect(dirExistsSyncStub).to.not.have.been.calledOnce;
       expect(fseMock.remove).to.not.have.been.called;


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #747

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

Appears to be that the cleanup function no longer checks the configuration, only `this.keepOutputDirectory` which appears to be a flag set by other processes

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I added a check for the configuration passing a `keepOutputDirectory` flag as well in the cleanup module.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Pass the `keepOutputDirectory` in the custom configuration as true. I've also added an additional test to check this.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
