### PR TITLE
Prevent ts-node being registered twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,13 @@ class ServerlessWebpack {
     this.options = options;
 
     if (
-      (_.has(this.serverless, 'service.custom.webpack') &&
-        _.isString(this.serverless.service.custom.webpack) &&
-        _.endsWith(this.serverless.service.custom.webpack, '.ts')) ||
-      (_.has(this.serverless, 'service.custom.webpack.webpackConfig') &&
-        _.endsWith(this.serverless.service.custom.webpack.webpackConfig, '.ts'))
+      (
+        (_.has(this.serverless, 'service.custom.webpack') &&
+          _.isString(this.serverless.service.custom.webpack) &&
+          _.endsWith(this.serverless.service.custom.webpack, '.ts')) ||
+        (_.has(this.serverless, 'service.custom.webpack.webpackConfig') &&
+          _.endsWith(this.serverless.service.custom.webpack.webpackConfig, '.ts'))
+      ) && !process[Symbol.for('ts-node.register.instance')]
     ) {
       try {
         require('ts-node/register');

--- a/index.test.js
+++ b/index.test.js
@@ -80,6 +80,15 @@ describe('ServerlessWebpack', () => {
       expect(Module._load).to.have.been.calledWith('ts-node/register');
     });
 
+    it('should not register ts-node if it has already been registered', () => {
+      _.set(serverless, 'service.custom.webpack.webpackConfig', 'webpack.config.ts');
+      process[Symbol.for('ts-node.register.instance')] = 'foo';
+      new ServerlessWebpack(serverless, {});
+      delete process[Symbol.for('ts-node.register.instance')];
+      expect(Module._load).to.not.have.been.called;
+      expect(Module._load).to.not.have.been.calledWith('ts-node/register');
+    });
+
     it('should throw an error if config use TS but ts-node was not added as dependency', () => {
       moduleStub.throws();
 


### PR DESCRIPTION
## What did you implement:

Relates to #404

It's currently not possible to use a `webpack.config.ts` file if also using a `serverless.ts` file. This is because `ts-node/register` is called twice resulting in `ts-node` trying to compile compiled Typescript.

Specifically, these errors are emitted:

```
api_1    |   TSError: ⨯ Unable to compile TypeScript:
api_1    |   webpack.config.ts(2,5): error TS7022: '__importDefault' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
api_1    |   webpack.config.ts(2,67): error TS7006: Parameter 'mod' implicitly has an 'any' type.
api_1    |   webpack.config.ts(45,29): error TS7006: Parameter 'resource' implicitly has an 'any' type.
```

## How did you implement it:

Using the suggestion posted [here](https://github.com/TypeStrong/ts-node/issues/846#issuecomment-631828160).

## How can we verify it:

1. Create a `serverless.ts` file AND a `webpack.config.ts` file
2. See errors above when trying to run any command that invokes serverless-webpack
3. Apply patch in this PR
4. Errors should disappear

## Todos:

- [x] Write tests
- [x] ~Write documentation~ (n/a?)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] ~Provide verification config / commands / resources~ (n/a?)
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
