### PR TITLE
Allow custom webpack config files to export as an ES6 module (interop default)

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -131,7 +131,8 @@ module.exports = {
         );
       }
       try {
-        this.webpackConfig = require(webpackConfigFilePath);
+        const webpackConfig = require(webpackConfigFilePath);
+        this.webpackConfig = webpackConfig.default || webpackConfig;
       } catch (err) {
         this.serverless.cli.log(`Could not load webpack config '${webpackConfigFilePath}'`);
         return BbPromise.reject(err);

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -271,6 +271,30 @@ describe('validate', () => {
         });
     });
 
+    it('should interop default when webpack config is exported as an ES6 module', () => {
+      const testConfig = 'testconfig';
+      const testServicePath = 'testpath';
+      const requiredPath = path.join(testServicePath, testConfig);
+      module.serverless.config.servicePath = testServicePath;
+      module.serverless.service.custom.webpack = testConfig;
+      serverless.utils.fileExistsSync = sinon.stub().returns(true);
+      const loadedConfig = {
+        default: {
+          entry: 'testentry'
+        }
+      };
+      mockery.registerMock(requiredPath, loadedConfig);
+      return expect(module.validate())
+        .to.fulfilled.then(() => {
+          expect(serverless.utils.fileExistsSync).to.have.been.calledWith(requiredPath);
+          expect(module.webpackConfig).to.eql(loadedConfig.default);
+          return null;
+        })
+        .finally(() => {
+          mockery.deregisterMock(requiredPath);
+        });
+    });
+
     it('should catch errors while loading a async webpack config from file if `custom.webpack` is a string', () => {
       const testConfig = 'testconfig';
       const testServicePath = 'testpath';


### PR DESCRIPTION
## What did you implement:

Resolves the problem described in [this comment](https://github.com/serverless-heaven/serverless-webpack/issues/404#issuecomment-395390852)

Webpack config must be exported using `module.export` syntax which particularly is an annoyance for Typescript environments that enforce `export` syntax.

## How did you implement it:

Check for `.default` in the imported config and fallback if not present.

## How can we verify it:

1. Create a custom webpack file that exports the config using `export default ...` syntax.

## Todos:

- [x] Write tests
- [x] ~Write documentation~ (n/a)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] ~Provide verification config / commands / resources~ (n/a)
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
