### PR TITLE
Regression Fix: Empty lines while stats: 'errors-only'

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -18,7 +18,12 @@ function ensureArray(obj) {
 }
 
 function getStatsLogger(statsConfig, consoleLog) {
-  return stats => consoleLog(stats.toString(statsConfig || defaultStatsConfig));
+  return stats => {
+    const statsOutput = stats.toString(statsConfig || defaultStatsConfig);
+    if (statsOutput) {
+      consoleLog(statsOutput);
+    }
+  };
 }
 
 function webpackCompile(config, logStats) {


### PR DESCRIPTION
## GENERAL:

Closes https://github.com/serverless-heaven/serverless-webpack/issues/499 https://github.com/serverless-heaven/serverless-webpack/pull/500

This is the **regression fix**.
Issue produced by https://github.com/serverless-heaven/serverless-webpack/pull/517 [here](https://github.com/serverless-heaven/serverless-webpack/pull/517/files#diff-54595458990a4e2e3a6b29f7ff36d7f60214fec64e21bdc0a195290552f030e8R32)

## How did you implement it:

Do not print empty console messages in case if compiled item stats return nothing.

## How can we verify it:

Setup webpack config with `stats: 'errors-only'` and run serverless deploy

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
