### PR TITLE
Add type to CLI options

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ class ServerlessWebpack {
         options: {
           out: {
             usage: 'Path to output directory',
-            shortcut: 'o'
+            shortcut: 'o',
+            type: 'string'
           }
         },
         commands: {


### PR DESCRIPTION
CLI options without type definition has been deprecated.
https://www.serverless.com/framework/docs/deprecations#cli-options-extensions-type-requirement

Fix #764 