### PR TITLE
fix excludeRegex by actually excluding files

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -27,15 +27,19 @@ function setArtifactPath(funcName, func, artifactPath) {
 
 function zip(directory, name) {
   // Check that files exist to be zipped
-  let files = glob.sync('**', {
+  const globFiles = glob.sync('**', {
     cwd: directory,
     dot: true,
     silent: true,
-    follow: true
+    follow: true,
+    nodir: true
   });
 
-  if (this.configuration.excludeRegex) {
-    files = _.filter(files, f => f.match(this.configuration.excludeRegex) === null);
+  const files = this.configuration.excludeRegex
+    ? _.filter(globFiles, f => f.match(this.configuration.excludeRegex) === null)
+    : globFiles;
+  if (files.length < globFiles.length && this.options.verbose) {
+    this.serverless.cli.log(`Excluded ${globFiles.length - files.length} file(s) based on excludeRegex`);
   }
 
   if (_.isEmpty(files)) {
@@ -49,7 +53,7 @@ function zip(directory, name) {
   this.serverless.utils.writeFileDir(artifactFilePath);
 
   const cwd = directory;
-  const source = '*';
+  const source = files;
   const destination = path.relative(cwd, artifactFilePath);
   const zipArgs = {
     source,
@@ -118,7 +122,9 @@ module.exports = {
           () =>
             this.options.verbose &&
             this.serverless.cli.log(
-              `Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'} (using ${hasNativeZip() ? 'native' : 'node'} method): ${modulePath} [${_.now() - startZip} ms]`
+              `Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'} (using ${
+                hasNativeZip() ? 'native' : 'node'
+              } method): ${modulePath} [${_.now() - startZip} ms]`
             )
         );
     });

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -83,7 +83,7 @@ module.exports = {
         }
 
         process.env.SLS_DEBUG &&
-          this.serverless.cli.log(`Webpack watch invoke: HASH NEW=${stats.hash} CUR=${lastHash}`);
+          this.serverless.cli.log(`Webpack watch invoke: HASH NEW=${stats && stats.hash} CUR=${lastHash}`);
 
         // If the file hash did not change there were no effective code changes detected
         // (comment changes do not change the compile hash and do not account for a rebuild!)


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #776 

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
* When querying a directory for files using `glob`, add a `nodir: true` parameter to have only actual files in the resulting `files` array.
* Filter the files using `excludeRegex` option if specified. If verbose, log the amount of excluded files.
* Then, when zipping files with `bestzip`, pass `files` instead of `"*"` so that only specified files end up in the zip.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->
webpack.config.js
```javascript
module.exports = {
    mode: 'production',
    target: 'node',
    devtool: 'source-map',
    resolve: {
        extensions: ['.mjs', '.ts', '.js']
    },
    output: {
        libraryTarget: 'commonjs2',
        path: path.join(__dirname, '.webpack'),
        filename: '[name].js'
    },
    externals: /^aws-sdk(\/.*)?/,
    // Place all node_modules in a separate vendor chunk
    optimization: {
        minimize: false,
        splitChunks: {
            chunks: 'all',
            maxInitialRequests: Infinity,
            minSize: 0,
            cacheGroups: {
                node_modules: {
                    test: /[\\/]node_modules[\\/]/,
                    name: 'vendor'
                }
            },
        },
    },
    module: {
        rules: [
            {
                test: /\.ts$/,
                exclude: /node_modules/,
                loader: 'ts-loader'
            }
        ]
    }
}
```


`excludeRegex`: `/.*\.map/`

Before:
```
demo-project
│   vendor.js
│   vendor.js.map
│
└───src
    └───handlers
            viewer-request.js
            viewer-request.js.map
```

After:
```
demo-project
│   vendor.js
│
└───src
    └───handlers
            viewer-request.js
```


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

P.S. I had to add an additional missing undefined-check in `lib/wpwatch.js` to pass 3 failing unit tests.