### PR TITLE
Fix `excludeRegex` option and allow dotfiles to be packaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ regex you want to exclude).
 # serverless.yml
 custom:
   webpack:
-    excludeRegex: /\.ts|test|\.map/
+    excludeRegex: \.ts|test|\.map
 ```
 
 #### Keep output directory after packaging

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -27,15 +27,19 @@ function setArtifactPath(funcName, func, artifactPath) {
 
 function zip(directory, name) {
   // Check that files exist to be zipped
-  let files = glob.sync('**', {
+  const globFiles = glob.sync('**', {
     cwd: directory,
     dot: true,
     silent: true,
-    follow: true
+    follow: true,
+    nodir: true
   });
 
-  if (this.configuration.excludeRegex) {
-    files = _.filter(files, f => f.match(this.configuration.excludeRegex) === null);
+  const files = this.configuration.excludeRegex
+    ? _.filter(globFiles, f => f.match(this.configuration.excludeRegex) === null)
+    : globFiles;
+  if (files.length < globFiles.length && this.options.verbose) {
+    this.serverless.cli.log(`Excluded ${globFiles.length - files.length} file(s) based on excludeRegex`);
   }
 
   if (_.isEmpty(files)) {
@@ -49,7 +53,7 @@ function zip(directory, name) {
   this.serverless.utils.writeFileDir(artifactFilePath);
 
   const cwd = directory;
-  const source = '*';
+  const source = files;
   const destination = path.relative(cwd, artifactFilePath);
   const zipArgs = {
     source,

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -35,15 +35,18 @@ function zip(directory, name) {
     nodir: true
   });
 
-  const files = this.configuration.excludeRegex
-    ? _.filter(globFiles, f => f.match(this.configuration.excludeRegex) === null)
-    : globFiles;
-  if (files.length < globFiles.length && this.options.verbose) {
-    this.serverless.cli.log(`Excluded ${globFiles.length - files.length} file(s) based on excludeRegex`);
+  let files = globFiles;
+  if (this.configuration.excludeRegex) {
+    files = _.filter(globFiles, f => f.match(this.configuration.excludeRegex) === null);
+
+    if (this.options.verbose) {
+      this.serverless.cli.log(`Excluded ${globFiles.length - files.length} file(s) based on excludeRegex`);
+    }
   }
 
   if (_.isEmpty(files)) {
     const error = new this.serverless.classes.Error('Packaging: No files found');
+
     return BbPromise.reject(error);
   }
 
@@ -52,14 +55,12 @@ function zip(directory, name) {
   const artifactFilePath = path.join(this.webpackOutputPath, name);
   this.serverless.utils.writeFileDir(artifactFilePath);
 
-  const cwd = directory;
-  const source = files;
-  const destination = path.relative(cwd, artifactFilePath);
   const zipArgs = {
-    source,
-    cwd,
-    destination
+    source: files,
+    cwd: directory,
+    destination: path.relative(directory, artifactFilePath)
   };
+
   return new BbPromise((resolve, reject) => {
     bestzip(zipArgs)
       .then(() => {

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -83,7 +83,7 @@ module.exports = {
         }
 
         process.env.SLS_DEBUG &&
-          this.serverless.cli.log(`Webpack watch invoke: HASH NEW=${stats.hash} CUR=${lastHash}`);
+          this.serverless.cli.log(`Webpack watch invoke: HASH NEW=${stats && stats.hash} CUR=${lastHash}`);
 
         // If the file hash did not change there were no effective code changes detected
         // (comment changes do not change the compile hash and do not account for a rebuild!)

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -312,7 +312,7 @@ describe('packageModules', () => {
       it('should reject if no files are found because all files are excluded using regex', () => {
         module.configuration = new Configuration({
           webpack: {
-            excludeRegex: /.*/
+            excludeRegex: '.*'
           }
         });
 

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -355,6 +355,54 @@ describe('packageModules', () => {
         module.compileStats = stats;
         return expect(module.packageModules()).to.be.rejectedWith('Packaging: No files found');
       });
+
+      it('should reject only .md files without verbose log', () => {
+        module.options.verbose = false;
+        module.configuration = new Configuration({
+          webpack: {
+            excludeRegex: '.md$'
+          }
+        });
+
+        // Test data
+        const stats = {
+          stats: [
+            {
+              compilation: {
+                compiler: {
+                  outputPath: '/my/Service/Path/.webpack/service'
+                }
+              }
+            }
+          ]
+        };
+        const files = [ 'README.md', 'src/handler1.js', 'src/handler1.js.map', 'src/handler2.js', 'src/handler2.js.map' ];
+        const allFunctions = [ 'func1', 'func2' ];
+        const func1 = {
+          handler: 'src/handler1',
+          events: []
+        };
+        const func2 = {
+          handler: 'src/handler2',
+          events: []
+        };
+        // Serverless behavior
+        getVersionStub.returns('1.18.0');
+        getServiceObjectStub.returns({
+          name: 'test-service'
+        });
+        getAllFunctionsStub.returns(allFunctions);
+        getFunctionStub.withArgs('func1').returns(func1);
+        getFunctionStub.withArgs('func2').returns(func2);
+        // Mock behavior
+        globMock.sync.returns(files);
+        fsMock._streamMock.on.withArgs('open').yields();
+        fsMock._streamMock.on.withArgs('close').yields();
+        fsMock._statMock.isDirectory.returns(false);
+
+        module.compileStats = stats;
+        return expect(module.packageModules()).to.be.fulfilled;
+      });
     });
 
     describe('with individual packaging', () => {


### PR DESCRIPTION
Supersed #777 (thanks @l1b3r!)
Fix #776
Fix #744

Most improvement on how exclude regex is working.
A message will now be logged in verbose mode so the user will know how many files were excluded (if any). It'll be easier to debug.

The zip command now receive a list of files to zip. It'll solve the dotfiles problem because we were using `*` as pattern to find files but this pattern does not include dotfiles by default (see #744).