### PR TITLE
Support local errors with NPM 7 workspaces 

### DIFF
--- a/lib/packagers/npm.js
+++ b/lib/packagers/npm.js
@@ -33,6 +33,7 @@ class NPM {
     ];
 
     const ignoredNpmErrors = [
+      { npmError: 'code ELSPROBLEMS', log: false }, // npm >= 7
       { npmError: 'extraneous', log: false },
       { npmError: 'missing', log: false },
       { npmError: 'peer dep missing', log: true }
@@ -44,7 +45,9 @@ class NPM {
       .catch(err => {
         if (err instanceof Utils.SpawnError) {
           // Only exit with an error if we have critical npm errors for 2nd level inside
-          const errors = _.split(err.stderr, '\n');
+          // ignoring any extra output from npm >= 7
+          const lines = _.split(err.stderr, '\n');
+          const errors = _.takeWhile(lines, line => line !== '{');
           const failed = _.reduce(
             errors,
             (failed, error) => {

--- a/lib/packagers/npm.test.js
+++ b/lib/packagers/npm.test.js
@@ -161,12 +161,61 @@ describe('npm', () => {
       );
   });
 
-  it('should ignore minor local NPM errors and log them', () => {
+  it('should ignore minor local NPM errors and log them (NPM < 7)', () => {
     const stderr = _.join(
       [
         'npm ERR! extraneous: sinon@2.3.8 ./babel-dynamically-entries/node_modules/serverless-webpack/node_modules/sinon',
         'npm ERR! missing: internalpackage-1@1.0.0, required by internalpackage-2@1.0.0',
         'npm ERR! peer dep missing: sinon@2.3.8'
+      ],
+      '\n'
+    );
+    const lsResult = {
+      version: '1.0.0',
+      problems: [
+        'npm ERR! extraneous: sinon@2.3.8 ./babel-dynamically-entries/node_modules/serverless-webpack/node_modules/sinon',
+        'npm ERR! missing: internalpackage-1@1.0.0, required by internalpackage-2@1.0.0',
+        'npm ERR! peer dep missing: sinon@2.3.8'
+      ],
+      dependencies: {
+        '@scoped/vendor': '1.0.0',
+        uuid: '^5.4.1',
+        bluebird: '^3.4.0'
+      }
+    };
+
+    Utils.spawnProcess.returns(
+      BbPromise.reject(new Utils.SpawnError('Command execution failed', JSON.stringify(lsResult), stderr))
+    );
+    return expect(npmModule.getProdDependencies('myPath', 1)).to.be.fulfilled.then(dependencies =>
+      BbPromise.all([
+        // npm ls and npm prune should have been called
+        expect(Utils.spawnProcess).to.have.been.calledOnce,
+        expect(Utils.spawnProcess.firstCall).to.have.been.calledWith(sinon.match(/^npm/), [
+          'ls',
+          '-prod',
+          '-json',
+          '-depth=1'
+        ]),
+        expect(dependencies).to.deep.equal(lsResult)
+      ])
+    );
+  });
+
+  it('should ignore minor local NPM errors and log them (NPM >= 7)', () => {
+    const stderr = _.join(
+      [
+        'npm ERR! code ELSPROBLEMS',
+        'npm ERR! extraneous: sinon@2.3.8 ./babel-dynamically-entries/node_modules/serverless-webpack/node_modules/sinon',
+        'npm ERR! missing: internalpackage-1@1.0.0, required by internalpackage-2@1.0.0',
+        'npm ERR! peer dep missing: sinon@2.3.8',
+        '{',
+        '  "error": {',
+        '    "code": "ELSPROBLEMS",',
+        '    "summary": "extraneous: sinon@2.3.8 ./babel-dynamically-entries/node_modules/serverless-webpack/node_modules/sinon\nmissing: internalpackage-1@1.0.0, required by internalpackage-2@1.0.0\npeer dep missing: sinon@2.3.8',
+        '    "detail": ""',
+        '  }',
+        '}'
       ],
       '\n'
     );


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #781

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

When parsing `npm ls` stderr, ignore `npm ERR! code ELSPROBLEMS` and then all lines after the opening `{` (start of JSON and error summary).

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

I added a new test.

It should also resolve the issue demonstrated at this minimum example repo: [boundstate/serverless-webpack-npm-7-example](https://github.com/boundstate/serverless-webpack-npm-7-example)

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
