### PR TITLE
Fix: Non node functions are attempted to be packaged

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -133,9 +133,7 @@ module.exports = {
 
   copyExistingArtifacts() {
     this.serverless.cli.log('Copying existing artifacts...');
-    // When invoked as a part of `deploy function`,
-    // only function passed with `-f` flag should be processed.
-    const functionNames = this.options.function ? [this.options.function] : this.serverless.service.getAllFunctions();
+    const functionNames = _.map(this.entryFunctions, 'funcName');
 
     // Copy artifacts to package location
     if (isIndividialPackaging.call(this)) {

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -133,7 +133,14 @@ module.exports = {
 
   copyExistingArtifacts() {
     this.serverless.cli.log('Copying existing artifacts...');
-    const functionNames = _.map(this.entryFunctions, 'funcName');
+    const functionNames = _.filter(
+      this.options.function ? [this.options.function] : this.serverless.service.getAllFunctions(),
+      funcName => {
+        const func = this.serverless.service.getFunction(funcName);
+        const runtime = func.runtime || this.serverless.service.provider.runtime || 'nodejs';
+        return runtime.match(/node/);
+      }
+    );
 
     // Copy artifacts to package location
     if (isIndividialPackaging.call(this)) {

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -133,18 +133,18 @@ module.exports = {
 
   copyExistingArtifacts() {
     this.serverless.cli.log('Copying existing artifacts...');
-    const functionNames = _.filter(
-      this.options.function ? [this.options.function] : this.serverless.service.getAllFunctions(),
-      funcName => {
-        const func = this.serverless.service.getFunction(funcName);
-        const runtime = func.runtime || this.serverless.service.provider.runtime || 'nodejs';
-        return runtime.match(/node/);
-      }
-    );
+    // When invoked as a part of `deploy function`,
+    // only function passed with `-f` flag should be processed.
+    const functionNames = this.options.function ? [this.options.function] : this.serverless.service.getAllFunctions();
 
     // Copy artifacts to package location
     if (isIndividialPackaging.call(this)) {
-      _.forEach(functionNames, funcName => copyArtifactByName.call(this, funcName));
+      const nodeFunctionNames = _.filter(functionNames, funcName => {
+        const func = this.serverless.service.getFunction(funcName);
+        const runtime = func.runtime || this.serverless.service.provider.runtime || 'nodejs';
+        return runtime.match(/node/);
+      });
+      _.forEach(nodeFunctionNames, funcName => copyArtifactByName.call(this, funcName));
     } else {
       // Copy service packaged artifact
       const serviceName = this.serverless.service.getServiceObject().name;

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -682,6 +682,8 @@ describe('packageModules', () => {
 
       it('copies only the artifact for function specified in options', () => {
         _.set(module, 'options.function', 'func1');
+        // when set to options.function is set, validate.js will only have that function as an entry point
+        _.set(module, 'entryFunctions', _.pickBy(entryFunctions, [ 'funcName', 'func1' ]));
         const expectedFunc1Destination = path.join('.serverless', 'func1.zip');
 
         return expect(module.copyExistingArtifacts()).to.be.fulfilled.then(() =>

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -477,16 +477,21 @@ describe('packageModules', () => {
   });
 
   describe('copyExistingArtifacts()', () => {
-    const allFunctions = [ 'func1', 'func2' ];
+    const allFunctions = [ 'func1', 'func2', 'funcPython' ];
     const func1 = {
       handler: 'src/handler1',
       events: []
     };
     const func2 = {
       handler: 'src/handler2',
-      events: []
+      events: [],
+      runtime: 'node'
     };
-
+    const funcPython = {
+      handler: 'src/handlerPython',
+      events: [],
+      runtime: 'python'
+    };
     const entryFunctions = [
       {
         handlerFile: 'src/handler1.js',
@@ -497,6 +502,11 @@ describe('packageModules', () => {
         handlerFile: 'src/handler2.js',
         funcName: 'func2',
         func: func2
+      },
+      {
+        handlerFile: 'src/handlerPython.js',
+        funcName: 'funcPython',
+        func: funcPython
       }
     ];
 
@@ -515,6 +525,7 @@ describe('packageModules', () => {
         getAllFunctionsStub.returns(allFunctions);
         getFunctionStub.withArgs('func1').returns(func1);
         getFunctionStub.withArgs('func2').returns(func2);
+        getFunctionStub.withArgs('funcPython').returns(funcPython);
       });
 
       it('copies the artifact', () => {
@@ -660,9 +671,10 @@ describe('packageModules', () => {
         getAllFunctionsStub.returns(allFunctions);
         getFunctionStub.withArgs('func1').returns(func1);
         getFunctionStub.withArgs('func2').returns(func2);
+        getFunctionStub.withArgs('funcPython').returns(funcPython);
       });
 
-      it('copies each artifact', () => {
+      it('copies each node artifact', () => {
         const expectedFunc1Destination = path.join('.serverless', 'func1.zip');
         const expectedFunc2Destination = path.join('.serverless', 'func2.zip');
 


### PR DESCRIPTION
## What did you implement:

Closes --

#579 helped in making webpack **not _compile_** any non-node functions, **BUT** the plugin still attempts to _**package**_ what it think would be webpack's output and fails miserably.  

This PR will make it so that non node runtime packages are also not attempted to be packaged.  

## How did you implement it:
`packageModules.js` will now only package functions set as `entryFunctions` so that any functions that were not not listed as entry points will not attempted to be packaged.  

## How can we verify it:

There's a unit test added, plus you could:  
```yaml
provider:
  name: aws
  runtime: nodejs12.x 

functions:
  node:
    handler: lambda.echo

  py:
    handler: backend.lambda.LambdaFunction
    runtime: python 
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR ([can't check this as this is an organization PR](https://github.com/isaacs/github/issues/1681))
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
