### PR TITLE
Fix the `spawn E2BIG` error when zipping

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -3,7 +3,7 @@
 const BbPromise = require('bluebird');
 const _ = require('lodash');
 const path = require('path');
-const { bestzip, hasNativeZip } = require('bestzip');
+const { nativeZip, nodeZip, hasNativeZip } = require('bestzip');
 const glob = require('glob');
 const semver = require('semver');
 const fs = require('fs');
@@ -27,21 +27,29 @@ function setArtifactPath(funcName, func, artifactPath) {
 
 function zip(directory, name) {
   // Check that files exist to be zipped
-  const globFiles = glob.sync('**', {
+  let files = glob.sync('**', {
     cwd: directory,
     dot: true,
     silent: true,
     follow: true,
     nodir: true
   });
+  let zipMethod = hasNativeZip ? nativeZip : nodeZip;
+  let source = hasNativeZip ? './' : '';
 
-  let files = globFiles;
+  // if excludeRegex option is defined, we'll have to list all files to be zipped
+  // and then force the node way to zip to avoid hitting the arguments limit (ie: E2BIG)
+  // when using the native way (ie: the zip command)
   if (this.configuration.excludeRegex) {
-    files = _.filter(globFiles, f => f.match(this.configuration.excludeRegex) === null);
+    const existingFilesLength = files.length;
+    files = _.filter(files, f => f.match(this.configuration.excludeRegex) === null);
 
     if (this.options.verbose) {
-      this.serverless.cli.log(`Excluded ${globFiles.length - files.length} file(s) based on excludeRegex`);
+      this.serverless.cli.log(`Excluded ${existingFilesLength - files.length} file(s) based on excludeRegex`);
     }
+
+    zipMethod = nodeZip;
+    source = files;
   }
 
   if (_.isEmpty(files)) {
@@ -56,15 +64,19 @@ function zip(directory, name) {
   this.serverless.utils.writeFileDir(artifactFilePath);
 
   const zipArgs = {
-    source: files,
+    source,
     cwd: directory,
     destination: path.relative(directory, artifactFilePath)
   };
 
   return new BbPromise((resolve, reject) => {
-    bestzip(zipArgs)
+    zipMethod(zipArgs)
       .then(() => {
         resolve(artifactFilePath);
+
+        this.options.verbose &&
+          this.serverless.cli.log(`Zip method used: ${zipMethod.name === 'nodeZip' ? 'node' : 'native'}`);
+
         return null;
       })
       .catch(err => {
@@ -123,9 +135,7 @@ module.exports = {
           () =>
             this.options.verbose &&
             this.serverless.cli.log(
-              `Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'} (using ${
-                hasNativeZip() ? 'native' : 'node'
-              } method): ${modulePath} [${_.now() - startZip} ms]`
+              `Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'}: ${modulePath} [${_.now() - startZip} ms]`
             )
         );
     });

--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -34,8 +34,13 @@ function zip(directory, name) {
     follow: true,
     nodir: true
   });
-  let zipMethod = hasNativeZip ? nativeZip : nodeZip;
-  let source = hasNativeZip ? './' : '';
+
+  let zipMethod = nodeZip;
+  let source = '';
+  if (hasNativeZip()) {
+    zipMethod = nativeZip;
+    source = './';
+  }
 
   // if excludeRegex option is defined, we'll have to list all files to be zipped
   // and then force the node way to zip to avoid hitting the arguments limit (ie: E2BIG)

--- a/tests/mocks/bestzip.mock.js
+++ b/tests/mocks/bestzip.mock.js
@@ -15,7 +15,8 @@ module.exports.create = sandbox => {
   hasNativeZip.returns(false);
 
   return {
-    bestzip: sinon.stub().resolves(BestZipMock(sandbox)),
+    nativeZip: sinon.stub().resolves(BestZipMock(sandbox)),
+    nodeZip: sinon.stub().resolves(BestZipMock(sandbox)),
     hasNativeZip
   };
 };

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -94,7 +94,7 @@ describe('packageModules', () => {
       module.compileStats = { stats: [] };
       return expect(module.packageModules()).to.be.fulfilled.then(() =>
         BbPromise.all([
-          expect(bestzipMock.bestzip).to.not.have.been.called,
+          expect(bestzipMock.nativeZip).to.not.have.been.called,
           expect(writeFileDirStub).to.not.have.been.called,
           expect(fsMock.createWriteStream).to.not.have.been.called,
           expect(globMock.sync).to.not.have.been.called
@@ -106,7 +106,7 @@ describe('packageModules', () => {
       module.skipCompile = true;
       return expect(module.packageModules()).to.be.fulfilled.then(() =>
         BbPromise.all([
-          expect(bestzipMock.bestzip).to.not.have.been.called,
+          expect(bestzipMock.nativeZip).to.not.have.been.called,
           expect(writeFileDirStub).to.not.have.been.called,
           expect(fsMock.createWriteStream).to.not.have.been.called,
           expect(globMock.sync).to.not.have.been.called


### PR DESCRIPTION
Closes #809

When the native method to zip is used, we give it a list of all files to be included in the archive.
Because of `node_modules`, that list can be very huge and then we hit a limit which broke the build with `spawn E2BIG` error.

We list files because we might need to filter them if the `excludeRegex` option is used.
So, the zip method is now forced to node in case of that option is defined.
Otherwise, we are using the method available (which might be the native one in most case) and we don't give it a list of files to be zipped but a folder (we don't use `*` because it'll omit dot files).

The only downside is if `excludeRegex` is defined, it'll use the node way to zip which is a big longer than the native one. In my tests, it took 2s more (native: 4s, node: 6s)