### PR TITLE
chore: use processedOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,10 @@ class ServerlessWebpack {
 
     this.hooks = {
       initialize: () => {
-        this.options = this.serverless.processedInput.options;
+        // serverless.processedInput does not exist in serverless@<2.0.0. This ensure the retrocompatibility with serverless v1
+        if (this.serverless.processedInput && this.serverless.processedInput.options) {
+          this.options = this.serverless.processedInput.options;
+        }
       },
       'before:package:createDeploymentArtifacts': () =>
         BbPromise.bind(this)

--- a/index.js
+++ b/index.js
@@ -90,6 +90,9 @@ class ServerlessWebpack {
     };
 
     this.hooks = {
+      initialize: () => {
+        this.options = this.serverless.processedInput.options;
+      },
       'before:package:createDeploymentArtifacts': () =>
         BbPromise.bind(this)
           .then(() => this.serverless.pluginManager.spawn('webpack:validate'))

--- a/index.test.js
+++ b/index.test.js
@@ -145,7 +145,9 @@ describe('ServerlessWebpack', () => {
 
     before(() => {
       slsw = new ServerlessWebpack(serverless, rawOptions);
-      serverless.processedInput.options = processedOptions;
+      if(serverless.processedInput) { // serverless.processedInput does not exist in serverless@<2.0.0
+        serverless.processedInput.options = processedOptions;
+      }
       sandbox.stub(slsw, 'cleanup').returns(BbPromise.resolve());
       sandbox.stub(slsw, 'watch').returns(BbPromise.resolve());
       sandbox.stub(slsw, 'wpwatch').returns(BbPromise.resolve());
@@ -475,7 +477,13 @@ describe('ServerlessWebpack', () => {
           test: () => {
             it('should override the raw options with the processed ones', () => {
               slsw.hooks.initialize();
-              expect(slsw.options).to.equal(processedOptions);
+              if(serverless.processedInput) {
+                expect(slsw.options).to.equal(processedOptions);
+              } else {
+                // serverless.processedInput does not exist in serverless@<2.0.0
+                // The options should not be changed
+                expect(slsw.options).to.equal(rawOptions);
+              }
             });
           }
         }

--- a/index.test.js
+++ b/index.test.js
@@ -134,10 +134,18 @@ describe('ServerlessWebpack', () => {
   );
 
   describe('hooks', () => {
+    const functionName = 'myFunction';
+    const rawOptions = {
+      f: functionName
+    };
+    const processedOptions = {
+      function: functionName
+    };
     let slsw;
 
     before(() => {
-      slsw = new ServerlessWebpack(serverless, {});
+      slsw = new ServerlessWebpack(serverless, rawOptions);
+      serverless.processedInput.options = processedOptions;
       sandbox.stub(slsw, 'cleanup').returns(BbPromise.resolve());
       sandbox.stub(slsw, 'watch').returns(BbPromise.resolve());
       sandbox.stub(slsw, 'wpwatch').returns(BbPromise.resolve());
@@ -459,6 +467,15 @@ describe('ServerlessWebpack', () => {
                 expect(slsw.serverless.pluginManager.spawn).to.have.been.calledWithExactly('webpack:compile');
                 return null;
               });
+            });
+          }
+        },
+        {
+          name: 'initialize',
+          test: () => {
+            it('should override the raw options with the processed ones', () => {
+              slsw.hooks.initialize();
+              expect(slsw.options).to.equal(processedOptions);
             });
           }
         }


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/serverless-heaven/serverless-webpack/issues/833

Use processed options as suggested by @medikoo in https://github.com/serverless/serverless/issues/9452 to improve the support for non-AWS providers

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

The raw options are now overridden by the processed options from `serverless.processedInput.options` during the initialize hook. (The first to be called at runtime)
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Example with the command `sls invoke local -f myFunctionName` on GCP.
Before: 
![Screenshot from 2021-05-17 17-26-47](https://user-images.githubusercontent.com/31917261/118515026-45f89200-b735-11eb-8417-ce3841fc95ce.png)
After:
![Screenshot from 2021-05-17 17-27-02](https://user-images.githubusercontent.com/31917261/118515039-4abd4600-b735-11eb-8d91-5e73d0b94157.png)

I also tested it on an existing AWS project to check it broke nothing.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
