### PR TITLE
(fix) allow boolean or number values in slsw.lib.options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,6 @@ declare module 'serverless-webpack' {
     entries: {
       [name: string]: string | string[];
     };
-    options: { [name: string]: string };
+    options: { [name: string]: string | boolean | number };
   };
 }


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This change relaxes the types for sls.lib.options object.
Makes it possible to use e.g. boolean options passed via serverless CLI in a typed webpack.config.ts without getting TS compile errors.

For example
```const watchEnabled = slsw.lib.options.watch === true; // now gives compile error saying watch must be a string```

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
