### PR TITLE
Register `serverless` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "sinon-chai": "^3.7.0"
   },
   "peerDependencies": {
+    "serverless": "1 || 2",
     "webpack": ">= 3.0.0 < 6"
   },
   "optionalDependencies": {


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_