### PR TITLE
Fallback on using service provider runtime / 'nodejs' in before:deploy:function:packageFunction hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ class ServerlessWebpack {
       'after:package:createDeploymentArtifacts': () => BbPromise.bind(this).then(this.cleanup),
 
       'before:deploy:function:packageFunction': () => {
-        const runtime = this.serverless.service.getFunction(this.options.function).runtime;
+        const runtime = this.serverless.service.getFunction(this.options.function).runtime || this.serverless.service.provider.runtime || 'nodejs';
 
         if (isNodeRuntime(runtime)) {
           return BbPromise.bind(this)


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When using "sls deploy function --function=function-name",
serverless-webpack would crash if the runtime was not set explicitly for
the function. This patch makes behavior consistent with other accesses
to the function runtime, falling back on the service provider's runtime
(or 'nodejs') if the function doesn't declare a runtime.

## How did you implement it:


## How can we verify it:

Without the patch, attempt to use 'sls deploy function --function=some_function' without a runtime set for the function. It will fail with an error similar to this:

```
  TypeError: Cannot read property 'match' of undefined
      at isNodeRuntime (/home/chris/git/project/node_modules/serverless-webpack/lib/utils.js:112:18)
      at Object.before:deploy:function:packageFunction [as hook] (/home/chris/git/project/node_modules/serverless-webpack/index.js:112:13)
      at PluginManager.invoke (/home/chris/.nvm/versions/node/v14.17.4/lib/node_modules/serverless/lib/classes/PluginManager.js:579:20)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at async PluginManager.run (/home/chris/.nvm/versions/node/v14.17.4/lib/node_modules/serverless/lib/classes/PluginManager.js:639:7)
      at async Serverless.run (/home/chris/.nvm/versions/node/v14.17.4/lib/node_modules/serverless/lib/Serverless.js:443:5)
      at async /home/chris/.nvm/versions/node/v14.17.4/lib/node_modules/serverless/scripts/serverless.js:750:9

```

After applying this patch, the operation should succeed.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** I think so
***Is it a breaking change?:*** NO
