### PR TITLE
Fixed new module identifier test external format

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -28,7 +28,7 @@ function getStatsLogger(statsConfig, consoleLog) {
 }
 
 function getExternalModuleName(module) {
-  const path = /^external "(.*)"$/.exec(module.identifier())[1];
+  const path = /^external.*\"(.*)"$/.exec(module.identifier())[1];
   const pathComponents = path.split('/');
   const main = pathComponents[0];
 


### PR DESCRIPTION
New regex to try to match i.e. `external commonjs "pino"` returned by webpack version ^5.52.0 (or earlier, dunno). Should also work when target is not present. otherwise you get a crash: TypeError: Cannot read property '1' of null

<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
