### PR TITLE
Fix the way to detect external module from Webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+* 5.5.4
+  * Fix the way to detect external module from Webpack ([#953][] @j0k3r)
+
+[#944]: https://github.com/serverless-heaven/serverless-webpack/pull/953
+
 * 5.5.3
   * Fallback on using service provider runtime when using `sls deploy function` ([#944][] @mostthingsweb)
 

--- a/index.js
+++ b/index.js
@@ -106,7 +106,10 @@ class ServerlessWebpack {
       'after:package:createDeploymentArtifacts': () => BbPromise.bind(this).then(this.cleanup),
 
       'before:deploy:function:packageFunction': () => {
-        const runtime = this.serverless.service.getFunction(this.options.function).runtime || this.serverless.service.provider.runtime || 'nodejs';
+        const runtime =
+          this.serverless.service.getFunction(this.options.function).runtime ||
+          this.serverless.service.provider.runtime ||
+          'nodejs';
 
         if (isNodeRuntime(runtime)) {
           return BbPromise.bind(this)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -28,7 +28,12 @@ function getStatsLogger(statsConfig, consoleLog) {
 }
 
 function getExternalModuleName(module) {
-  const path = /^external "(.*)"$/.exec(module.identifier())[1];
+  const pathArray = /^external .*"(.*?)"$/.exec(module.identifier());
+  if (!pathArray) {
+    throw new Error(`Unable to extract module name from Webpack identifier: ${module.identifier()}`);
+  }
+
+  const path = pathArray[1];
   const pathComponents = path.split('/');
   const main = pathComponents[0];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "serverless-webpack",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.5.3",
+      "version": "5.5.4",
       "license": "MIT",
       "dependencies": {
         "bestzip": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -217,33 +217,21 @@ describe('compile', () => {
               outputPath: 'compileStats-outputPath'
             },
             modules: [
-              {
-                identifier: _.constant('"crypto"')
-              },
-              {
-                identifier: _.constant('"uuid/v4"')
-              },
-              {
-                identifier: _.constant('"mockery"')
-              },
-              {
-                identifier: _.constant('"@scoped/vendor/module1"')
-              },
-              {
-                identifier: _.constant('external "@scoped/vendor/module2"')
-              },
-              {
-                identifier: _.constant('external "uuid/v4"')
-              },
-              {
-                identifier: _.constant('external "localmodule"')
-              },
-              {
-                identifier: _.constant('external "bluebird"')
-              },
-              {
-                identifier: _.constant('external "aws-sdk"')
-              }
+              { identifier: _.constant('"crypto"') },
+              { identifier: _.constant('"uuid/v4"') },
+              { identifier: _.constant('"mockery"') },
+              { identifier: _.constant('"@scoped/vendor/module1"') },
+              { identifier: _.constant('external "@scoped/vendor/module2"') },
+              { identifier: _.constant('external "uuid/v4"') },
+              { identifier: _.constant('external "localmodule"') },
+              { identifier: _.constant('external "bluebird"') },
+              { identifier: _.constant('external "aws-sdk"') },
+              { identifier: _.constant('external node-commonjs "lodash"') },
+              { identifier: _.constant('external commonjs-module "globby"') },
+              { identifier: _.constant('external this "glob"') },
+              { identifier: _.constant('external module "semver"') },
+              { identifier: _.constant('external assign "whatever"') },
+              { identifier: _.constant('external umd2 "hiyou"') }
             ]
           },
           toString: sandbox.stub().returns('testStats'),
@@ -261,9 +249,41 @@ describe('compile', () => {
         { external: 'uuid', origin: undefined },
         { external: 'localmodule', origin: undefined },
         { external: 'bluebird', origin: undefined },
-        { external: 'aws-sdk', origin: undefined }
+        { external: 'aws-sdk', origin: undefined },
+        { external: 'lodash', origin: undefined },
+        { external: 'globby', origin: undefined },
+        { external: 'glob', origin: undefined },
+        { external: 'semver', origin: undefined },
+        { external: 'whatever', origin: undefined },
+        { external: 'hiyou', origin: undefined }
       ]);
       return null;
     });
+  });
+
+  it('should fail to set stats externals', () => {
+    const testWebpackConfig = 'testconfig';
+    const multiStats = {
+      stats: [
+        {
+          compilation: {
+            errors: [],
+            compiler: {
+              outputPath: 'compileStats-outputPath'
+            },
+            modules: [{ identifier: _.constant('external node-commonjs "aws-sdk".') }]
+          },
+          toString: sandbox.stub().returns('testStats'),
+          hasErrors: _.constant(false)
+        }
+      ]
+    };
+    module.webpackConfig = testWebpackConfig;
+    module.configuration = { concurrency: 1 };
+    webpackMock.compilerMock.run.reset();
+    webpackMock.compilerMock.run.yields(null, multiStats);
+    return expect(module.compile()).to.be.rejectedWith(
+      'Unable to extract module name from Webpack identifier: external node-commonjs "aws-sdk".'
+    );
   });
 });


### PR DESCRIPTION
Fix #950 (the bug was introduced by Webpack 5.52.0)
Superseded #951

Also prepare release 5.5.4 to quickly release the bug fix.