### PR TITLE
Fixes issue causing remote image strings to not be accepted by the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,15 @@ functions:
         - app.handler2
 ```
 
+If you want to use a remote docker image but still need the webpack process before doing so, you can specify it as indicated below:
+
+```yaml
+# serverless.yml
+functions:
+  myFunction1:
+    image: public.ecr.aws/lambda/nodejs:latest
+```
+
 ## Usage
 
 ### Automatic bundling

--- a/README.md
+++ b/README.md
@@ -592,13 +592,16 @@ functions:
         - app.handler2
 ```
 
-If you want to use a remote docker image but still need the webpack process before doing so, you can specify it as indicated below:
+If you want to use a remote docker image but still need the webpack process before doing so, you can specify it as indicated below. 
+This will include this handler into webpack build but still uses the user defined image as the source image. This case is specially
+usefull for processes that build their images on the go with the webpack built source and deploy to an ECR repository for example.
 
 ```yaml
 # serverless.yml
 functions:
   myFunction1:
     image: public.ecr.aws/lambda/nodejs:latest
+    handler: index.js
 ```
 
 ## Usage

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,9 +118,9 @@ function getAllNodeFunctions() {
   return _.filter(functions, funcName => {
     const func = this.serverless.service.getFunction(funcName);
 
-    // if `uri` is provided or simple remote image path, it means the 
-    // image isn't built by Serverless so we shouldn't take care of it
-    if ((func.image && func.image.uri) || (func.image && typeof func.image == 'string')) {
+    // if `uri` is provided or simple remote image path BUT NO HANDLER, 
+    // it means the image isn't built by Serverless so we shouldn't take care of it
+    if (((func.image && func.image.uri) || (func.image && typeof func.image == 'string')) && !func.handler) {
       return false;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,8 +118,9 @@ function getAllNodeFunctions() {
   return _.filter(functions, funcName => {
     const func = this.serverless.service.getFunction(funcName);
 
-    // if `uri` is provided, it means the image isn't built by Serverless so we shouldn't take care of it
-    if (func.image && func.image.uri) {
+    // if `uri` is provided or simple remote image path, it means the 
+    // image isn't built by Serverless so we shouldn't take care of it
+    if ((func.image && func.image.uri) || (func.image && typeof func.image == 'string')) {
       return false;
     }
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -25,6 +25,8 @@ module.exports = {
         return handlerProp;
       }
 
+      if (imageProp && typeof imageProp == 'string') return imageProp;
+
       if (!imageProp || !imageProp.command || imageProp.command.length < 1) {
         const docsLink = 'https://www.serverless.com/blog/container-support-for-lambda';
         throw new this.serverless.classes.Error(

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -795,6 +795,51 @@ describe('validate', () => {
         }).to.throw(/Either function.handler or function.image must be defined/);
       });
 
+      it('should not throw error if container image is a simple string', () => {
+        const testOutPath = 'test';
+        const testFunctionsConfig = {
+          func1: {
+            artifact: 'artifact-func1.zip',
+            events: [
+              {
+                http: {
+                  method: 'POST',
+                  path: 'func1path'
+                }
+              },
+              {
+                nonhttp: 'non-http'
+              }
+            ],
+            image: 'XXXX.dkr.ecr.ca-central-1.amazonaws.com/myproject/customNode:latest'
+          }
+        };
+
+        const testConfig = {
+          entry: 'test',
+          context: 'testcontext',
+          output: {
+            path: testOutPath
+          },
+          getFunction: func => {
+            return testFunctionsConfig[func];
+          }
+        };
+
+        _.set(module.serverless.service, 'custom.webpack.config', testConfig);
+        module.serverless.service.functions = testFunctionsConfig;
+        globSyncStub.callsFake(filename => [_.replace(filename, '*', 'js')]);
+        return expect(module.validate()).to.be.fulfilled.then(() => {
+          const lib = require('../lib/index');
+          const expectedLibEntries = {};
+
+          expect(lib.entries).to.deep.equal(expectedLibEntries);
+          expect(globSyncStub).to.have.callCount(0);
+          expect(serverless.cli.log).to.not.have.been.called;
+          return null;
+        });
+      });
+
       describe('google provider', () => {
         beforeEach(() => {
           _.set(module.serverless, 'service.provider.name', 'google');


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Amend fixes on https://github.com/serverless-heaven/serverless-webpack/issues/825 

Issue introduced with image command detection, preventing simple remote images to be used when in usage with webpack plugin. The use case is custom nodejs images built on the fly with the code and pushed on ECR (implemented and used by Hybridless plugin https://github.com/Hybridless/hybridless).

Serverless documentation also indicates its support. (Please, scroll to the very bottom, last example) https://www.serverless.com/blog/container-support-for-lambda

## How did you implement it:

Prevent inclusion of the 'image' into webpack entries, and also detect the image string before checking for the image name. 

## How can we verify it:

```
service: report-support
provider:
  name: aws
  region: ca-central-1
  runtime: nodejs12.x
  stage: ${opt:stage, 'dev'}
  versionFunctions: false
plugins:
  - serverless-webpack
functions:
  server:
    image: public.ecr.aws/lambda/nodejs:latest
    handler: handler.func
custom:
  webpack:
    webpackConfig: api/webpack.config.js
    packager: yarn
    keepOutputDirectory: true
```

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
