### PR TITLE
Fix v1 test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,51 +18,51 @@ jobs:
           - windows-latest
           - ubuntu-18.04
         node:
-          - "10"
-          - "12"
-          - "14"
+          - '10'
+          - '12'
+          - '14'
 
     steps:
-      - name: "Checkout"
+      - name: 'Checkout'
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: "Install Node.js"
+      - name: 'Install Node.js'
         uses: actions/setup-node@v2
         with:
-          node-version: "${{ matrix.node }}"
+          node-version: '${{ matrix.node }}'
 
-      - name: "Install dependencies"
+      - name: 'Install dependencies'
         run: npm ci
 
-      - name: "Run tests"
-        run: "npm run test"
+      - name: 'Run tests'
+        run: 'npm run test'
 
   coverage:
-    name: "Upload coverage"
+    name: 'Upload coverage'
     runs-on: ubuntu-20.04
     needs:
-      - "mocha"
+      - 'mocha'
 
     steps:
-      - name: "Checkout"
+      - name: 'Checkout'
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: "Install Node.js"
+      - name: 'Install Node.js'
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: '12'
 
-      - name: "Install dependencies"
+      - name: 'Install dependencies'
         run: npm ci
 
-      - name: "Run tests"
-        run: "npm run test-coverage"
+      - name: 'Run tests'
+        run: 'npm run test-coverage'
 
-      - name: "Upload to Coveralls"
+      - name: 'Upload to Coveralls'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,24 +76,24 @@ jobs:
         os:
           - ubuntu-20.04
         node:
-          - "14"
+          - '14'
 
     steps:
-      - name: "Checkout"
+      - name: 'Checkout'
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: "Install Node.js"
+      - name: 'Install Node.js'
         uses: actions/setup-node@v2
         with:
-          node-version: "${{ matrix.node }}"
+          node-version: '${{ matrix.node }}'
 
-      - name: "Install Serverless v1"
-        run: npm install serverless@"<2.0.0"
+      - name: 'Install Serverless v1'
+        run: npm install serverless@1"
 
-      - name: "Install dependencies"
+      - name: 'Install dependencies'
         run: npm ci
 
-      - name: "Run tests"
-        run: "npm run test"
+      - name: 'Run tests'
+        run: 'npm run test'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           node-version: '${{ matrix.node }}'
 
       - name: 'Install Serverless v1'
-        run: npm install serverless@1"
+        run: npm install serverless@1
 
       - name: 'Install dependencies'
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,51 +18,51 @@ jobs:
           - windows-latest
           - ubuntu-18.04
         node:
-          - '10'
-          - '12'
-          - '14'
+          - "10"
+          - "12"
+          - "14"
 
     steps:
-      - name: 'Checkout'
+      - name: "Checkout"
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: 'Install Node.js'
+      - name: "Install Node.js"
         uses: actions/setup-node@v2
         with:
-          node-version: '${{ matrix.node }}'
+          node-version: "${{ matrix.node }}"
 
-      - name: 'Install dependencies'
+      - name: "Install dependencies"
         run: npm ci
 
-      - name: 'Run tests'
-        run: 'npm run test'
+      - name: "Run tests"
+        run: "npm run test"
 
   coverage:
-    name: 'Upload coverage'
+    name: "Upload coverage"
     runs-on: ubuntu-20.04
     needs:
-      - 'mocha'
+      - "mocha"
 
     steps:
-      - name: 'Checkout'
+      - name: "Checkout"
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: 'Install Node.js'
+      - name: "Install Node.js"
         uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: "12"
 
-      - name: 'Install dependencies'
+      - name: "Install dependencies"
         run: npm ci
 
-      - name: 'Run tests'
-        run: 'npm run test-coverage'
+      - name: "Run tests"
+        run: "npm run test-coverage"
 
-      - name: 'Upload to Coveralls'
+      - name: "Upload to Coveralls"
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,24 +76,24 @@ jobs:
         os:
           - ubuntu-20.04
         node:
-          - '14'
+          - "14"
 
     steps:
-      - name: 'Checkout'
+      - name: "Checkout"
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: 'Install Node.js'
+      - name: "Install Node.js"
         uses: actions/setup-node@v2
         with:
-          node-version: '${{ matrix.node }}'
+          node-version: "${{ matrix.node }}"
 
-      - name: 'Install Serverless v1'
+      - name: "Install Serverless v1"
         run: npm install serverless@1
 
-      - name: 'Install dependencies'
+      - name: "Install dependencies"
         run: npm ci
 
-      - name: 'Run tests'
-        run: 'npm run test'
+      - name: "Run tests"
+        run: "npm run test"


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Indirectly solves serverless-heaven/serverless-webpack#966, from a [slack reply](https://serverless-contrib.slack.com/archives/CA4QT5VU3/p1633007676202800?thread_ts=1632995606.201600&cid=CA4QT5VU3) we know that serverless has recently deprecated all v1. Pinning down major version should force an installation, also better matches with the test name.

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

Changes `npm install serverless@"<2.0.0"` to `npm install serverless@1`.

## How can we verify it:

The test `Node.js ${{ matrix.node }} on ${{ matrix.os }} with Serverless v1` should pass.

## Todos:

- [ ] ~~Write tests~~
- [ ] ~~Write documentation~~
- [ ] ~~Fix linting errors~~
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
