### PR TITLE
Avoid a JS error when the Webpack config is not found

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -120,6 +120,10 @@ module.exports = {
     this.serverless.cli.log('Bundling with Webpack...');
 
     const configs = ensureArray(this.webpackConfig);
+    if (configs[0] === undefined) {
+      return BbPromise.reject('Unable to find Webpack configuration');
+    }
+
     const logStats = getStatsLogger(configs[0].stats, this.serverless.cli.consoleLog);
 
     if (!this.configuration) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,7 +118,7 @@ function getAllNodeFunctions() {
   return _.filter(functions, funcName => {
     const func = this.serverless.service.getFunction(funcName);
 
-    // if `uri` is provided or simple remote image path, it means the 
+    // if `uri` is provided or simple remote image path, it means the
     // image isn't built by Serverless so we shouldn't take care of it
     if ((func.image && func.image.uri) || (func.image && typeof func.image == 'string')) {
       return false;

--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -74,6 +74,10 @@ describe('compile', () => {
   });
 
   it('should fail if configuration is missing', () => {
+    return expect(module.compile()).to.be.rejectedWith('Unable to find Webpack configuration');
+  });
+
+  it('should fail if plugin configuration is missing', () => {
     const testWebpackConfig = 'testconfig';
     module.webpackConfig = testWebpackConfig;
     module.configuration = undefined;


### PR DESCRIPTION
In case the Webpack config can't be found, throw an error instead of the useless JS error:

```
TypeError: Cannot read property 'stats' of undefined
```

Fix #907