### PR TITLE
Fix user error reporting

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -79,7 +79,7 @@ function getExternalModules({ compilation }) {
   return Array.from(externals);
 }
 
-function webpackCompile(config, logStats) {
+function webpackCompile(config, logStats, ServerlessError) {
   return BbPromise.fromCallback(cb => webpack(config).run(cb)).then(stats => {
     // ensure stats in any array in the case of concurrent build.
     stats = stats.stats ? stats.stats : [stats];
@@ -87,7 +87,7 @@ function webpackCompile(config, logStats) {
     _.forEach(stats, compileStats => {
       logStats(compileStats);
       if (compileStats.hasErrors()) {
-        throw new Error('Webpack compilation error, see stats above');
+        throw new ServerlessError('Webpack compilation error, see stats above');
       }
     });
 
@@ -98,9 +98,9 @@ function webpackCompile(config, logStats) {
   });
 }
 
-function webpackConcurrentCompile(configs, logStats, concurrency) {
-  return BbPromise.map(configs, config => webpackCompile(config, logStats), { concurrency }).then(stats =>
-    _.flatten(stats)
+function webpackConcurrentCompile(configs, logStats, concurrency, ServerlessError) {
+  return BbPromise.map(configs, config => webpackCompile(config, logStats, ServerlessError), { concurrency }).then(
+    stats => _.flatten(stats)
   );
 }
 
@@ -116,11 +116,11 @@ module.exports = {
     const logStats = getStatsLogger(configs[0].stats, this.serverless.cli.consoleLog);
 
     if (!this.configuration) {
-      return BbPromise.reject('Missing plugin configuration');
+      return BbPromise.reject(new this.serverless.classes.Error('Missing plugin configuration'));
     }
     const concurrency = this.configuration.concurrency;
 
-    return webpackConcurrentCompile(configs, logStats, concurrency).then(stats => {
+    return webpackConcurrentCompile(configs, logStats, concurrency, this.serverless.classes.Error).then(stats => {
       this.compileStats = { stats };
       return BbPromise.resolve();
     });


### PR DESCRIPTION
In Serverless Framework all user errors are expected to be reported with `ServerlessError` instance (class accessible at `this.serverless.classes.Error`) otherwise error is assumed as programmatic, and when thrown, whole stack trace is presented.

This patch ensures that those common user errors are reported with `ServerlessError`