### PR TITLE
Centralize webpack stats config handling (refactor)

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -3,16 +3,8 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
-const tty = require('tty');
 const isBuiltinModule = require('is-builtin-module');
-
-const defaultStatsConfig = {
-  colors: tty.isatty(process.stdout.fd),
-  hash: false,
-  version: false,
-  chunks: false,
-  children: false
-};
+const logStats = require('./logStats');
 
 function ensureArray(obj) {
   return _.isArray(obj) ? obj : [obj];
@@ -20,10 +12,7 @@ function ensureArray(obj) {
 
 function getStatsLogger(statsConfig, consoleLog) {
   return stats => {
-    const statsOutput = stats.toString(statsConfig || defaultStatsConfig);
-    if (statsOutput) {
-      consoleLog(statsOutput);
-    }
+    logStats(stats, statsConfig, consoleLog);
   };
 }
 

--- a/lib/logStats.js
+++ b/lib/logStats.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const tty = require('tty');
+
+const defaultStatsConfig = {
+  colors: tty.isatty(process.stdout.fd),
+  hash: false,
+  version: false,
+  chunks: false,
+  children: false
+};
+
+module.exports = function (stats, statsConfig, consoleLog) {
+  const statsOutput = stats.toString(statsConfig || defaultStatsConfig);
+  if (statsOutput) {
+    consoleLog(statsOutput);
+  }
+};

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const webpack = require('webpack');
-const tty = require('tty');
+const logStats = require('./logStats');
 
 module.exports = {
   wpwatch() {
@@ -60,14 +60,7 @@ module.exports = {
       });
     }
 
-    const consoleStats = this.webpackConfig.stats || {
-      colors: tty.isatty(process.stdout.fd),
-      hash: false,
-      version: false,
-      chunks: false,
-      children: false
-    };
-
+    const consoleStats = this.webpackConfig.stats;
     // This starts the watch and waits for the immediate compile that follows to end or fail.
     let lastHash = null;
 
@@ -98,10 +91,7 @@ module.exports = {
 
         if (stats) {
           lastHash = stats.hash;
-          const statsOutput = stats.toString(consoleStats);
-          if (statsOutput) {
-            this.serverless.cli.consoleLog(stats.toString(consoleStats));
-          }
+          logStats(stats, consoleStats, this.serverless.cli.consoleLog);
         }
 
         if (firstRun) {


### PR DESCRIPTION
This refactor centralizes default webpack log stats configuration, so it's in one place, and not scattered in two