### PR TITLE
feat(compiler): add noBuild option

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,6 @@ custom:
 
 > Note that only relative path is supported at the moment.
 
-
 `peerDependencies` of all above external dependencies will also be packed into the Serverless
 artifact. By default, `node_modules` in the same directory as `package.json` (current working directory
 or specified by`packagePath`) will be used.
@@ -576,12 +575,14 @@ custom:
 Will run each webpack build one at a time which helps reduce memory usage and in some cases impoves overall build performance.
 
 ### Support for Docker Images as Custom Runtimes
+
 AWS Lambda and `serverless` started supporting the use of Docker images as custom runtimes in 2021. See the [serverless documentation](https://www.serverless.com/blog/container-support-for-lambda) for details on how to configure a `serverless.yml` to use these features.
 
 **NOTE: You must provide an override for the Image `CMD` property in your function definitions.**
 See [Dockerfile documentation](https://docs.docker.com/engine/reference/builder/#cmd) for more information about the native Docker `CMD` property.
 
 In the following example `entrypoint` is inherited from the shared Docker image, while `command` is provided as an override for each function:
+
 ```yaml
 # serverless.yml
 functions:
@@ -633,17 +634,16 @@ All options that are supported by invoke local can be used as usual:
 
 > :exclamation: The old `webpack invoke` command has been disabled.
 
-#### Run a function with an existing compiled output (--no-build)
+#### Run a function with an existing compiled output
 
 On CI systems it is likely that you'll run multiple integration tests with `invoke local`
 sequentially. To improve this, you can do one compile and run multiple invokes on the
 compiled output - it is not necessary to compile again before each and every invoke.
 
-```bash
-$ serverless webpack
-$ serverless invoke local --function <function-name-1> --no-build
-$ serverless invoke local --function <function-name-2> --no-build
-...
+```yaml
+custom:
+  webpack:
+    noBuild: true
 ```
 
 ### Run a function locally on source changes

--- a/index.js
+++ b/index.js
@@ -178,10 +178,6 @@ class ServerlessWebpack {
         BbPromise.bind(this)
           .tap(() => {
             lib.webpack.isLocal = true;
-            // --no-build override
-            if (this.options.build === false) {
-              this.skipCompile = true;
-            }
           })
           .then(this.prepareOfflineInvoke)
           .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),
@@ -190,10 +186,6 @@ class ServerlessWebpack {
         BbPromise.bind(this)
           .tap(() => {
             lib.webpack.isLocal = true;
-            // --no-build override
-            if (this.options.build === false) {
-              this.skipCompile = true;
-            }
           })
           .then(this.prepareOfflineInvoke)
           .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),

--- a/index.test.js
+++ b/index.test.js
@@ -451,7 +451,7 @@ describe('ServerlessWebpack', () => {
               });
             });
             it('should skip compiling when requested', () => {
-              slsw.skipCompile = false;
+              slsw.skipCompile = true;
               slsw.options.build = false;
               return expect(slsw.hooks['before:offline:start:init']()).to.be.fulfilled.then(() => {
                 expect(ServerlessWebpack.lib.webpack.isLocal).to.be.true;

--- a/lib/prepareOfflineInvoke.js
+++ b/lib/prepareOfflineInvoke.js
@@ -9,6 +9,9 @@ const path = require('path');
 
 module.exports = {
   prepareOfflineInvoke() {
+    this.skipCompile =
+      _.get(this.serverless, 'service.custom.webpack.noBuild') === true || _.get(this.options, 'build') === false;
+
     // Use service packaging for compile
     _.set(this.serverless, 'service.package.individually', false);
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -192,9 +192,11 @@ module.exports = {
         this.webpackConfig.output.path = path.join(this.serverless.config.servicePath, this.options.out);
       }
 
-      // Skip compilation with --no-build
-      if (this.options.build === false) {
-        this.skipCompile = true;
+      this.skipCompile =
+        _.get(this.serverless, 'service.custom.webpack.noBuild') === true || _.get(this.options, 'build') === false;
+
+      // Skip compilation with --no-build or noBuild
+      if (this.skipCompile) {
         this.serverless.cli.log('Skipping build and using existing compiled output');
         if (!fse.pathExistsSync(this.webpackConfig.output.path)) {
           return BbPromise.reject(new this.serverless.classes.Error('No compiled output found'));


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #965

I removed the `--no-build` CLI option from README to discourage usage, the actual feature is kept for backward compatibility.

## How did you implement it:

```yml
custom:
  webpack:
    noBuild: true
```

## How can we verify it:

```bash
> serverless deploy
> serverless invoke local
> serverless offline
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
