### PR TITLE
5.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.5.5",
+  "version": "5.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.5.5",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
         "bestzip": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.5.5",
+  "version": "5.6.0",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Proposed release note:

## Detailled changes

1. There is now a `noInstall` options in `packagerOptions` (for both NPM & Yarn) to skip deps installation during the Serverless package / deployement. If you enable that option, be sure packages are installed **before**.

    ```yaml
    custom:
      webpack:
        packagerOptions:
          noInstall: true
    ```

2. The `--no-build` CLI argument has been removed.
  You should now define it inside your Serverless configuration:

    ```yaml
    custom:
      webpack:
        noBuild: true
    ```

3. The `--watch` CLI argument has been improved and now works properly.

## What's Changed
* Avoid a JS error when the Webpack config is not found by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1002
* feat(packager): add noInstall option by @russell-dot-js in https://github.com/serverless-heaven/serverless-webpack/pull/1003
* Centralize webpack stats config handling (refactor) by @medikoo in https://github.com/serverless-heaven/serverless-webpack/pull/1006
* Fix command resolution when watch is involved by @medikoo in https://github.com/serverless-heaven/serverless-webpack/pull/1004
* feat(compiler): add noBuild option by @vicary in https://github.com/serverless-heaven/serverless-webpack/pull/1007
* Fix user error reporting by @medikoo in https://github.com/serverless-heaven/serverless-webpack/pull/1005


**Full Changelog**: https://github.com/serverless-heaven/serverless-webpack/compare/v5.5.5...v5.6.0