### PR TITLE
Fix handling of multiple compilation errors

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -87,7 +87,7 @@ function webpackCompile(config, logStats, ServerlessError) {
     _.forEach(stats, compileStats => {
       logStats(compileStats);
       if (compileStats.hasErrors()) {
-        throw new ServerlessError('Webpack compilation error, see stats above');
+        throw _.assign(new ServerlessError('Webpack compilation error, see stats above'), { stats: compileStats });
       }
     });
 
@@ -99,9 +99,22 @@ function webpackCompile(config, logStats, ServerlessError) {
 }
 
 function webpackConcurrentCompile(configs, logStats, concurrency, ServerlessError) {
-  return BbPromise.map(configs, config => webpackCompile(config, logStats, ServerlessError), { concurrency }).then(
-    stats => _.flatten(stats)
-  );
+  const errors = [];
+  return BbPromise.map(
+    configs,
+    config =>
+      webpackCompile(config, logStats, ServerlessError).catch(error => {
+        errors.push(error);
+        return error.stats;
+      }),
+    { concurrency }
+  ).then(stats => {
+    if (errors.length) {
+      if (errors.length === 1) throw errors[0];
+      throw new ServerlessError('Webpack compilation errors, see stats above');
+    }
+    return _.flatten(stats);
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
Currently, when compiling multiple bundles, the first error is reported, and the rest are reported in the air (after the command is reported as finalized).

This patch fixes, so all errors are acknowledged, and that command reports final error when compilations of all bundles finalizes