### PR TITLE
Mark plugin as Serverless Framework v3 compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "sinon-chai": "^3.7.0"
   },
   "peerDependencies": {
-    "serverless": "1 || 2",
+    "serverless": "1 || 2 || 3",
     "webpack": ">= 3.0.0 < 6"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Plugin as is, will work with Serverless Framework v3 without issues, therefore it'll be great to mark it as compliant (so it doesn't report a lack of compatibility once v3 is released)

For complete adaptation, it'll be great if it also comes with modern logs (addressed at https://github.com/serverless-heaven/serverless-webpack/pull/1013)