### PR TITLE
Fix filesystem cache not working when package individually is set

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -16,6 +16,10 @@ function getStatsLogger(statsConfig, consoleLog, { log, ServerlessError }) {
   };
 }
 
+function isIndividialPackaging() {
+  return _.get(this.serverless, 'service.package.individually');
+}
+
 function getExternalModuleName(module) {
   const pathArray = /^external .*"(.*?)"$/.exec(module.identifier());
   if (!pathArray) {
@@ -120,11 +124,21 @@ function webpackConcurrentCompile(configs, logStats, concurrency, ServerlessErro
   const errors = [];
   return BbPromise.map(
     configs,
-    config =>
-      webpackCompile(config, logStats).catch(error => {
+    config => {
+      if (isIndividialPackaging.call(this) && _.get(config, 'cache.type') === 'filesystem') {
+        const clonedConfig = _.clone(config);
+        const entryFunc = _.find(this.entryFunctions, ['entry.key', _.keys(config.entry)[0]]);
+        clonedConfig.cache.name = entryFunc.func.name;
+        return webpackCompile(clonedConfig, logStats, ServerlessError).catch(error => {
+          errors.push(error);
+          return error.stats;
+        });
+      }
+      return webpackCompile(config, logStats, ServerlessError).catch(error => {
         errors.push(error);
         return error.stats;
-      }),
+      });
+    },
     { concurrency }
   ).then(stats => {
     if (errors.length) {

--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -119,7 +119,7 @@ describe('compile', () => {
             },
             modules: []
           },
-          toString: sandbox.stub().returns('testStats'),
+          toString: jest.fn().mockReturnValue('testStats'),
           hasErrors: _.constant(false)
         }
       ]
@@ -143,21 +143,23 @@ describe('compile', () => {
         }
       }
     ];
-    webpackMock.compilerMock.run.reset();
-    webpackMock.compilerMock.run.yields(null, multiStats);
-    return expect(module.compile()).to.be.fulfilled.then(() => {
-      expect(webpackMock).to.have.been.calledWith({
-        cache: {
-          type: 'filesystem',
-          name: 'service-stage-function-name'
-        },
-        entry: {
-          'function-name/handler': './function-name/handler.js'
-        }
+    webpackMock.compilerMock.run.mockClear();
+    webpackMock.compilerMock.run.mockImplementation(cb => cb(null, multiStats));
+    return expect(module.compile())
+      .resolves.toBeUndefined()
+      .then(() => {
+        expect(webpackMock).toHaveBeenCalledWith({
+          cache: {
+            type: 'filesystem',
+            name: 'service-stage-function-name'
+          },
+          entry: {
+            'function-name/handler': './function-name/handler.js'
+          }
+        });
+        expect(webpackMock.compilerMock.run).toHaveBeenCalledTimes(1);
+        return null;
       });
-      expect(webpackMock.compilerMock.run).to.have.been.calledOnce;
-      return null;
-    });
   });
 
   it('should work with concurrent compile', () => {
@@ -224,7 +226,7 @@ describe('compile', () => {
             },
             modules: []
           },
-          toString: sandbox.stub().returns('testStats'),
+          toString: jest.fn().mockReturnValue('testStats'),
           hasErrors: _.constant(false)
         }
       ]
@@ -260,30 +262,32 @@ describe('compile', () => {
         }
       }
     ];
-    webpackMock.compilerMock.run.reset();
-    webpackMock.compilerMock.run.yields(null, multiStats);
-    return expect(module.compile()).to.be.fulfilled.then(() => {
-      expect(webpackMock).to.have.been.calledWith({
-        cache: {
-          type: 'filesystem',
-          name: 'service-stage-function-name-1'
-        },
-        entry: {
-          'function-name-1/handler': './function-name-1/handler.js'
-        }
+    webpackMock.compilerMock.run.mockClear();
+    webpackMock.compilerMock.run.mockImplementation(cb => cb(null, multiStats));
+    return expect(module.compile())
+      .resolves.toBeUndefined()
+      .then(() => {
+        expect(webpackMock).toHaveBeenCalledWith({
+          cache: {
+            type: 'filesystem',
+            name: 'service-stage-function-name-1'
+          },
+          entry: {
+            'function-name-1/handler': './function-name-1/handler.js'
+          }
+        });
+        expect(webpackMock).toHaveBeenCalledWith({
+          cache: {
+            type: 'filesystem',
+            name: 'service-stage-function-name-2'
+          },
+          entry: {
+            'function-name-2/handler': './function-name-2/handler.js'
+          }
+        });
+        expect(webpackMock.compilerMock.run).toHaveBeenCalledTimes(2);
+        return null;
       });
-      expect(webpackMock).to.have.been.calledWith({
-        cache: {
-          type: 'filesystem',
-          name: 'service-stage-function-name-2'
-        },
-        entry: {
-          'function-name-2/handler': './function-name-2/handler.js'
-        }
-      });
-      expect(webpackMock.compilerMock.run).to.have.been.calledTwice;
-      return null;
-    });
   });
 
   it('should use correct stats option', () => {


### PR DESCRIPTION

## What did you implement:

Fix a bug that occurs when using webpack cache type "filesystem" when package.individually === true
The error displaying by webpack:
```
[webpack.cache.PackFileCacheStrategy] Caching failed for pack: Error: ENOENT: no such file or directory, rename '[...].cache/webpack/default-production/0.pack.gz_' -> '[...].cache/webpack/default-production/0.pack.gz'
```

Root cause: Webpack filesystem cache generate cache files to the same cache location, with the same cache name, no matter how many times it runs. When package individually and concurrently, multiple concurrent webpack runs results in overlapping of cache location for each individual functions, overwriting each other's caches.

## How did you implement it:

Webpack will create a different cache folder name only if webpackConfig.cache.name is not the same [(link)](https://webpack.js.org/configuration/cache/#cachename)
Each time webpackCompile() is called, it needs a separate config that has a different cache.name
The best way to work this out is when individually caching, set the config that is used to package the function to have the cache.name as the function name, which is preformatted to be `{serviceName}-{stage}-{functionName}`

## How can we verify it:

Enable cache.type = "filesystem"
Package a service with package.individually = true

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
