### PR TITLE
README: Clarify versions supported by the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage Status][ico-coverage]][link-coverage]
 [![Contributors][ico-contributors]][link-contributors]
 
-A Serverless v1.x & v2.x plugin to build your lambda functions with [Webpack][link-webpack].
+A Serverless Framework plugin to build your lambda functions with [Webpack][link-webpack].
 
 This plugin is for you if you want to use the latest Javascript version with [Babel][link-babel];
 use custom [resource loaders][link-webpack-loaders], optimize your packaged functions individually


### PR DESCRIPTION
I figured instead of listing all versions I might as well simplify the sentence? (v0.5 is very very old now).