### PR TITLE
(fix) allow param values in slsw.lib.options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,6 @@ declare module 'serverless-webpack' {
     entries: {
       [name: string]: string | string[];
     };
-    options: { [name: string]: string | boolean | number };
+    options: { [name: string]: string | boolean | number } & { param?: string[] };
   };
 }


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Serverless Framework v3.3 accepts multiple param options, see https://github.com/serverless/serverless/issues/9817.
These are presented in options as a string array, which is incompatible with the previous definition of CLI options included in serverless-webpack.

## How did you implement it:

I modified the typings so I can use `slsw.lib.options.param.include('xxxx')` in my webpack.config.ts file.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
