### PR TITLE
Prepare 5.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.6.1",
+      "version": "5.7.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Proposed changelog:

```
## Detailed changes

1. @medikoo changed the output log when using Serverless v3, it's less verbose and more clean

   _progress:_
   <img width="487" alt="Screenshot 2021-10-13 at 17 50 37" src="https://user-images.githubusercontent.com/122434/143237872-43418fee-f9ed-4d43-9dfb-c7597acdd045.png">

   _success:_
   <img width="483" alt="Screenshot 2021-10-13 at 17 50 08" src="https://user-images.githubusercontent.com/122434/143237899-04fe85f0-797f-4169-94fc-e9e6acac3fec.png">

2. We switch back to `archiver` instead of `bestzip` to ensure consistent artifact. The switch to bestzip was mostly to faster zip because it tend to use the native zip command instead of the one from Node.
3. Support for NPM 8 was added

## What's Changed
* Clarify versions supported by the plugin by @mnapoli in https://github.com/serverless-heaven/serverless-webpack/pull/1056
* Fix tests with Serverless v3 by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1062
* Modern logs for Serverless Framework v3 by @medikoo in https://github.com/serverless-heaven/serverless-webpack/pull/1013
* Ensure consistent artifact `sha` (remove `bestzip` and bring back `archiver`) by @russell-dot-js & @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1018
* Allow param values in `slsw.lib.options` by @coyoteecd in https://github.com/serverless-heaven/serverless-webpack/pull/1076
* Supports NPM 8 and convert tests from Mocha to Jest by @moroine in https://github.com/serverless-heaven/serverless-webpack/pull/1084
* Update Jest config by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1110
* Fix filesystem cache not working when package individually is set by @hieuunguyeen in https://github.com/serverless-heaven/serverless-webpack/pull/1037

## New Contributors
* @mnapoli made their first contribution in https://github.com/serverless-heaven/serverless-webpack/pull/1056
* @moroine made their first contribution in https://github.com/serverless-heaven/serverless-webpack/pull/1084
* @hieuunguyeen made their first contribution in https://github.com/serverless-heaven/serverless-webpack/pull/1037

**Full Changelog**: https://github.com/serverless-heaven/serverless-webpack/compare/v5.6.1...v5.7.0
```