### PR TITLE
Fix `this.serverless` is undefined during zip

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -143,7 +143,7 @@ function zip(directory, zipFileName) {
   const artifactFilePath = path.join(this.webpackOutputPath, zipFileName);
   this.serverless.utils.writeFileDir(artifactFilePath);
 
-  return serverlessZip({
+  return serverlessZip.call(this, {
     directory,
     artifactFilePath,
     files


### PR DESCRIPTION
Calling `serverlessZip` directly does not _inject_ (or hydrate) the `this` inside the `serverlessZip`.
We need to use `.call` for that.

Fix https://github.com/serverless-heaven/serverless-webpack/issues/1140