### PR TITLE
Prepare 5.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.7.0",
+      "version": "5.7.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Prepare release 5.7.1, changelog:

<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* Update build status badge by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1154
* Fix `this.serverless` is undefined during zip by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1153


**Full Changelog**: https://github.com/serverless-heaven/serverless-webpack/compare/v5.7.0...v5.7.1