### PR TITLE
Avoid future update of Jest >= 28

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
       - dependency-name: mocha
         versions:
           - ">= 9.0.0"
+      # require node > 10
+      - dependency-name: jest
+        versions:
+          - ">= 28.0.0"


### PR DESCRIPTION
Because we support Node 10 and Jest 28 dont.

See:
- https://github.com/serverless-heaven/serverless-webpack/pull/1150
- https://github.com/serverless-heaven/serverless-webpack/runs/6366164236?check_suite_focus=true

![image](https://user-images.githubusercontent.com/62333/167585929-3796bec6-ad93-4ef2-91d1-dae1811d17cd.png)
