### PR TITLE
Match NPM `--ignore-scripts` w/ Yarn Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ The NPM packager supports the following `packagerOptions`:
 
 | Option             | Type   | Default               | Description                                         |
 | ------------------ | ------ | --------------------- | --------------------------------------------------- |
+| ignoreScripts      | bool   | false                 | Do not execute package.json hook scripts on install |
 | noInstall          | bool   | false                 | Do not run `npm install` (assume install completed) |
 | lockFile           | string | ./package-lock.json   | Relative path to lock file to use                   |
 

--- a/lib/packagers/npm.js
+++ b/lib/packagers/npm.js
@@ -124,6 +124,10 @@ class NPM {
     const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
     const args = ['install'];
 
+    if (packagerOptions.ignoreScripts) {
+      args.push('--ignore-scripts');
+    }
+
     return Utils.spawnProcess(command, args, { cwd }).return();
   }
 

--- a/tests/packagers/npm.test.js
+++ b/tests/packagers/npm.test.js
@@ -51,6 +51,23 @@ describe('npm', () => {
           return null;
         });
     });
+
+    it('should use ignoreScripts option', () => {
+      Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(npmModule.install('myPath', { ignoreScripts: true }))
+        .resolves.toBeUndefined()
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenCalledWith(
+            expect.stringMatching(/^npm/),
+            ['install', '--ignore-scripts'],
+            {
+              cwd: 'myPath'
+            }
+          );
+          return null;
+        });
+    });
   });
 
   describe('noInstall', () => {


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

Allow NPM packager to use `--ignore-scripts` option to match Yarn behavior. This is useful for skipping build/compile steps that are irrelevant because AWS Lambda is a different CPU architecture than the build machine.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Copied implementation from Yarn.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

```yml
custom:
  webpack:
    packagerOptions:
      ignoreScripts: true
```

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
