### PR TITLE
Add the `--skip-build` CLI option 

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "lint-staged && npm test"
+    "pre-commit": "npx lint-staged"
   }
 }

--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,4 +1,2 @@
 "*.js":
-  - "prettier-eslint --write"             # Run Prettier
-  - "eslint"                              # Run TSLint
-  - "git add"
+  - "eslint"

--- a/README.md
+++ b/README.md
@@ -662,6 +662,16 @@ On CI systems it is likely that you'll run multiple integration tests with `invo
 sequentially. To improve this, you can do one compile and run multiple invokes on the
 compiled output - it is not necessary to compile again before each and every invoke.
 
+##### Using the CLI option `--skip-build`
+
+```bash
+$ serverless webpack
+$ serverless invoke local --function <function-name-1> --skip-build
+$ serverless invoke local --function <function-name-2> --skip-build
+```
+
+##### Using the parameter `noBuild`
+
 ```yaml
 custom:
   webpack:
@@ -736,7 +746,7 @@ e.g. a mounted volume in a Docker container, you can enable polling with the
 `--webpack-use-polling=<time in ms>` option. If you omit the value, it defaults
 to 3000 ms.
 
-If you don't want the plugin to build when using `serverless-offline`, select the `--no-build` option.
+If you don't want the plugin to build when using `serverless-offline`, select the `--skip-build` option.
 
 #### Custom paths
 

--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ class ServerlessWebpack {
         commands: {
           local: {
             options: {
+              'skip-build': {
+                usage: 'Skip Webpack compilation',
+                type: 'boolean'
+              },
               watch: {
                 usage: 'Flag to watch changes',
                 type: 'boolean'
@@ -113,6 +117,10 @@ class ServerlessWebpack {
           'webpack-no-watch': {
             usage: 'Disable automatic watch mode from Serverless Webpack',
             type: 'boolean'
+          },
+          'skip-build': {
+            usage: 'Skip Webpack compilation',
+            type: 'boolean'
           }
         },
         commands: {
@@ -120,6 +128,10 @@ class ServerlessWebpack {
             options: {
               'webpack-no-watch': {
                 usage: 'Disable automatic watch mode from Serverless Webpack',
+                type: 'boolean'
+              },
+              'skip-build': {
+                usage: 'Skip Webpack compilation',
                 type: 'boolean'
               }
             }
@@ -217,6 +229,10 @@ class ServerlessWebpack {
         BbPromise.bind(this)
           .tap(() => {
             lib.webpack.isLocal = true;
+            // --skip-build override
+            if (this.options['skip-build'] === false) {
+              this.skipCompile = true;
+            }
           })
           .then(this.prepareOfflineInvoke)
           .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),
@@ -225,6 +241,10 @@ class ServerlessWebpack {
         BbPromise.bind(this)
           .tap(() => {
             lib.webpack.isLocal = true;
+            // --skip-build override
+            if (this.options['skip-build'] === false) {
+              this.skipCompile = true;
+            }
           })
           .then(this.prepareOfflineInvoke)
           .then(() => (this.skipCompile ? BbPromise.resolve() : this.wpwatch())),

--- a/lib/prepareOfflineInvoke.js
+++ b/lib/prepareOfflineInvoke.js
@@ -10,7 +10,7 @@ const path = require('path');
 module.exports = {
   prepareOfflineInvoke() {
     this.skipCompile =
-      _.get(this.serverless, 'service.custom.webpack.noBuild') === true || _.get(this.options, 'build') === false;
+      _.get(this.serverless, 'service.custom.webpack.noBuild') === true || _.get(this.options, 'skip-build') === true;
 
     // Use service packaging for compile
     _.set(this.serverless, 'service.package.individually', false);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -223,9 +223,9 @@ module.exports = {
       }
 
       this.skipCompile =
-        _.get(this.serverless, 'service.custom.webpack.noBuild') === true || _.get(this.options, 'build') === false;
+        _.get(this.serverless, 'service.custom.webpack.noBuild') === true || _.get(this.options, 'skip-build') === true;
 
-      // Skip compilation with --no-build or noBuild
+      // Skip compilation with --skip-build or noBuild
       if (this.skipCompile) {
         if (this.log) {
           this.log('Skipping build and using existing compiled output');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -219,7 +219,7 @@ describe('ServerlessWebpack', () => {
             });
 
             it('should skip compile if requested', () => {
-              slsw.options.build = false;
+              slsw.options['skip-build'] = false;
               slsw.skipCompile = true;
               return expect(slsw.hooks['before:invoke:local:invoke']())
                 .resolves.toBeUndefined()
@@ -377,8 +377,7 @@ describe('ServerlessWebpack', () => {
           name: 'before:offline:start',
           test: () => {
             it('should prepare offline', () => {
-              slsw.skipCompile = false;
-              slsw.options.build = true;
+              slsw.options['skip-build'] = true;
               return expect(slsw.hooks['before:offline:start']())
                 .resolves.toBeUndefined()
                 .then(() => {
@@ -389,8 +388,7 @@ describe('ServerlessWebpack', () => {
                 });
             });
             it('should skip compiling when requested', () => {
-              slsw.skipCompile = true;
-              slsw.options.build = false;
+              slsw.options['skip-build'] = false;
               return expect(slsw.hooks['before:offline:start']())
                 .resolves.toBeUndefined()
                 .then(() => {
@@ -406,8 +404,7 @@ describe('ServerlessWebpack', () => {
           name: 'before:offline:start:init',
           test: () => {
             it('should prepare offline', () => {
-              slsw.skipCompile = false;
-              slsw.options.build = true;
+              slsw.options['skip-build'] = true;
               return expect(slsw.hooks['before:offline:start:init']())
                 .resolves.toBeUndefined()
                 .then(() => {
@@ -418,8 +415,7 @@ describe('ServerlessWebpack', () => {
                 });
             });
             it('should skip compiling when requested', () => {
-              slsw.skipCompile = true;
-              slsw.options.build = false;
+              slsw.options['skip-build'] = false;
               return expect(slsw.hooks['before:offline:start:init']())
                 .resolves.toBeUndefined()
                 .then(() => {

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -1188,7 +1188,7 @@ describe('validate', () => {
   });
 
   describe('with skipped builds', () => {
-    it('should set `skipCompile` to true if `options.build` is false', () => {
+    it('should set `skipCompile` to true if `options.skip-build` is true', () => {
       const testConfig = {
         entry: 'test',
         output: {}
@@ -1197,7 +1197,7 @@ describe('validate', () => {
       module.serverless.config.servicePath = testServicePath;
       _.set(module.serverless.service, 'custom.webpack.config', testConfig);
 
-      module.options.build = false;
+      module.options['skip-build'] = true;
 
       fsExtraMock.pathExistsSync.mockReturnValue(true);
       return module.validate().then(() => {
@@ -1214,7 +1214,7 @@ describe('validate', () => {
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
       _.set(module.serverless.service, 'custom.webpack.config', testConfig);
-      module.options.build = false;
+      module.options['skip-build'] = true;
       fsExtraMock.pathExistsSync.mockReturnValue(true);
       return module.validate().then(() => {
         expect(module.keepOutputDirectory).toBe(true);
@@ -1230,7 +1230,7 @@ describe('validate', () => {
       const testServicePath = 'testpath';
       module.serverless.config.servicePath = testServicePath;
       _.set(module.serverless.service, 'custom.webpack.config', testConfig);
-      module.options.build = false;
+      module.options['skip-build'] = true;
       fsExtraMock.pathExistsSync.mockReturnValue(false);
       return expect(module.validate()).rejects.toThrow(/No compiled output found/);
     });


### PR DESCRIPTION
We removed it because it was generating some deprecated message and we introduced the parameter `noBuild` instead.
Now the CLI option is back and the parameter is kept.

Kind of revert https://github.com/serverless-heaven/serverless-webpack/pull/1007

Double fix #965

The first commit is from https://github.com/serverless-heaven/serverless-webpack/pull/1187, it'll be dropped once the PR is merged and that one is rebased.