### PR TITLE
Prepare 5.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.7.1",
+      "version": "5.8.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Prepare release 5.8.0, changelog:

---
## Main changes
1. We have added a new CLI option `--skip-build` which has the same behavior of the previous removed CLI option `--no-build`. That option allows to run a function with an existing compiled output. (see https://github.com/serverless-heaven/serverless-webpack/pull/1190)

2. We have also properly defined CLI options to remove all errors like _Detected unrecognized CLI options_ when using Serverless > v1 (see https://github.com/serverless-heaven/serverless-webpack/pull/1187)

## What's Changed
* Avoid future update of Jest >= 28 by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1156
* Match NPM `--ignore-scripts` w/ Yarn Support by @hnryjms in https://github.com/serverless-heaven/serverless-webpack/pull/1186
* fix: `packagerOption` lockFile is now properly used (for NPM) by @moroine in https://github.com/serverless-heaven/serverless-webpack/pull/1191
* fix: dependabot-automerge by @vicary in https://github.com/serverless-heaven/serverless-webpack/pull/1198
* Define Serverless Webpack CLI options on other commands by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1187
* Add the `--skip-build` CLI option  by @j0k3r in https://github.com/serverless-heaven/serverless-webpack/pull/1190

## New Contributors
* @hnryjms made their first contribution in https://github.com/serverless-heaven/serverless-webpack/pull/1186

**Full Changelog**: https://github.com/serverless-heaven/serverless-webpack/compare/v5.7.1...v5.8.0