### PR TITLE
Prepare 5.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.8.0",
+      "version": "5.9.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
# v5.9.0

## Main Changes 

1. Webpack entries can now be overridden via function option `entrypoint` in `serverless.yml`
2. Fix a warning of undefined plugin CLI option `--webpack-use-polling`

## What's Changed

- feat: function level entry overrides by @kirrg001 in #1220
- Add type of --webpack-use-polling option by @emiksk in #1213 

## New Contributors

- @kirrg001 made their first contribution in #1220 
- @emiksk made their first contribution in #1213 

**Full Changelog: https://github.com/serverless-heaven/serverless-webpack/compare/v5.8.0...release/5.9.0**