### PR TITLE
Add new `packagerOptions`: `noNonInteractive` to disable interactive mode when using Yarn 2 or above

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ The yarn packager supports the following `packagerOptions`:
 | ------------------ | ---- | ------- | --------------------------------------------------- |
 | ignoreScripts      | bool | false   | Do not execute package.json hook scripts on install |
 | noInstall          | bool | false   | Do not run `yarn install` (assume install completed)|
+| noNonInteractive   | bool | false   | Disable interactive mode when using Yarn 2 or above |
 | noFrozenLockfile   | bool | false   | Do not require an up-to-date yarn.lock              |
 | networkConcurrency | int  |         | Specify number of concurrent network requests       |
 

--- a/lib/packagers/yarn.js
+++ b/lib/packagers/yarn.js
@@ -5,6 +5,7 @@
  * Yarn specific packagerOptions (default):
  *   flat (false) - Use --flat with install
  *   ignoreScripts (false) - Do not execute scripts during install
+ *   noNonInteractive (false) - Disable interactive mode when using Yarn 2 or above
  *   noFrozenLockfile (false) - Do not require an up-to-date yarn.lock
  *   networkConcurrency (8) - Specify number of concurrent network requests
  */
@@ -123,9 +124,12 @@ class Yarn {
     }
 
     const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
-    const args = ['install', '--non-interactive'];
+    const args = ['install'];
 
     // Convert supported packagerOptions
+    if (!packagerOptions.noNonInteractive) {
+      args.push('--non-interactive');
+    }
     if (!packagerOptions.noFrozenLockfile) {
       args.push('--frozen-lockfile');
     }

--- a/tests/packagers/yarn.test.js
+++ b/tests/packagers/yarn.test.js
@@ -213,6 +213,23 @@ describe('yarn', () => {
         });
     });
 
+    it('should use noNonInteractive option', () => {
+      Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(yarnModule.install('myPath', { noNonInteractive: true }))
+        .resolves.toBeUndefined()
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenCalledWith(
+            expect.stringMatching(/^yarn/),
+            ['install', '--frozen-lockfile'],
+            {
+              cwd: 'myPath'
+            }
+          );
+          return null;
+        });
+    });
+
     it('should use ignoreScripts option', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
       return expect(yarnModule.install('myPath', { ignoreScripts: true }))


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes [#642](https://github.com/serverless-heaven/serverless-webpack/issues/642)

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Add a new flag `noNonInteractive` to `packagerOptions` when using `yarn` as the `packager`.

If using Yarn 2 or above the flag `--non-interactive` will break `yarn install`.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

`npm run test`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
