### PR TITLE
Prepare 5.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.9.1",
+      "version": "5.10.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Changelog:

<!-- Release notes generated using configuration in .github/release.yml at master -->

## Main Changes
- The lib is finally compatible with Yarn 2 (and above)! Thanks to @jagonzalr (and others involved in #642).

## What's Changed
* Add new `packagerOptions`: `noNonInteractive` to disable interactive mode when using Yarn 2 or above by @jagonzalr in https://github.com/serverless-heaven/serverless-webpack/pull/1246
* fix: prevent duplicate artifact assignment by @NoxHarmonium in https://github.com/serverless-heaven/serverless-webpack/pull/1245

## New Contributors
* @jagonzalr made their first contribution in https://github.com/serverless-heaven/serverless-webpack/pull/1246
* @NoxHarmonium made their first contribution in https://github.com/serverless-heaven/serverless-webpack/pull/1245

**Full Changelog**: https://github.com/serverless-heaven/serverless-webpack/compare/v5.9.1...v5.10.0