### PR TITLE
Detect yarn version to dynamically not add deprecated flags

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -397,17 +397,20 @@ module.exports = {
               } else {
                 this.serverless.cli.log('Packing external modules: ' + compositeModules.join(', '));
               }
-              return packager
-                .install(compositeModulePath, this.configuration.packagerOptions)
-                .then(() => {
-                  if (this.log) {
-                    this.log.verbose(`Package took [${_.now() - start} ms]`);
-                  } else {
-                    this.options.verbose && this.serverless.cli.log(`Package took [${_.now() - start} ms]`);
-                  }
-                  return null;
-                })
-                .return(stats.stats);
+
+              return packager.getPackagerVersion(compositeModulePath).then(version => {
+                return packager
+                  .install(compositeModulePath, this.configuration.packagerOptions, version)
+                  .then(() => {
+                    if (this.log) {
+                      this.log.verbose(`Package took [${_.now() - start} ms]`);
+                    } else {
+                      this.options.verbose && this.serverless.cli.log(`Package took [${_.now() - start} ms]`);
+                    }
+                    return null;
+                  })
+                  .return(stats.stats);
+              });
             })
             .mapSeries(compileStats => {
               const modulePath = compileStats.outputPath;
@@ -485,13 +488,15 @@ module.exports = {
                 .then(() => {
                   // Prune extraneous packages - removes not needed ones
                   const startPrune = _.now();
-                  return packager.prune(modulePath, this.configuration.packagerOptions).tap(() => {
-                    if (this.log) {
-                      this.log.verbose(`Prune: ${modulePath} [${_.now() - startPrune} ms]`);
-                    } else {
-                      this.options.verbose &&
-                        this.serverless.cli.log(`Prune: ${modulePath} [${_.now() - startPrune} ms]`);
-                    }
+                  return packager.getPackagerVersion(modulePath).then(version => {
+                    return packager.prune(modulePath, this.configuration.packagerOptions, version).tap(() => {
+                      if (this.log) {
+                        this.log.verbose(`Prune: ${modulePath} [${_.now() - startPrune} ms]`);
+                      } else {
+                        this.options.verbose &&
+                          this.serverless.cli.log(`Prune: ${modulePath} [${_.now() - startPrune} ms]`);
+                      }
+                    });
                   });
                 })
                 .then(() => {

--- a/lib/packagers/index.js
+++ b/lib/packagers/index.js
@@ -9,6 +9,7 @@
  * static get lockfileName(): string;
  * static get copyPackageSectionNames(): Array<string>;
  * static get mustCopyModules(): boolean;
+ * static getPackagerVersion(cwd: string): BbPromise<Object>
  * static getProdDependencies(cwd: string, depth: number = 1): BbPromise<Object>;
  * static rebaseLockfile(pathToPackageRoot: string, lockfile: Object): void;
  * static install(cwd: string): BbPromise<void>;

--- a/lib/packagers/npm.js
+++ b/lib/packagers/npm.js
@@ -25,6 +25,17 @@ class NPM {
     return true;
   }
 
+  static getPackagerVersion(cwd) {
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    const args = ['-v'];
+
+    return Utils.spawnProcess(command, args, { cwd })
+      .catch(err => {
+        return BbPromise.resolve({ stdout: err.stdout });
+      })
+      .then(processOutput => processOutput.stdout);
+  }
+
   static getProdDependencies(cwd, depth, packagerOptions) {
     // Try to use NPM lockfile v2 when possible
     const options = packagerOptions || {};

--- a/lib/packagers/yarn.js
+++ b/lib/packagers/yarn.js
@@ -29,6 +29,23 @@ class Yarn {
     return false;
   }
 
+  static isBerryVersion(version) {
+    const versionNumber = version.charAt(0);
+    const mainVersion = parseInt(versionNumber);
+    return mainVersion > 1;
+  }
+
+  static getPackagerVersion(cwd) {
+    const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
+    const args = ['-v'];
+
+    return Utils.spawnProcess(command, args, { cwd })
+      .catch(err => {
+        return BbPromise.resolve({ stdout: err.stdout });
+      })
+      .then(processOutput => processOutput.stdout);
+  }
+
   static getProdDependencies(cwd, depth) {
     const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
     const args = ['list', `--depth=${depth || 1}`, '--json', '--production'];
@@ -118,20 +135,24 @@ class Yarn {
     return _.reduce(replacements, (__, replacement) => _.replace(__, replacement.oldRef, replacement.newRef), lockfile);
   }
 
-  static install(cwd, packagerOptions) {
+  static install(cwd, packagerOptions, version) {
     if (packagerOptions.noInstall) {
       return BbPromise.resolve();
     }
+    const isBerry = Yarn.isBerryVersion(version);
 
     const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
     const args = ['install'];
-
     // Convert supported packagerOptions
-    if (!packagerOptions.noNonInteractive) {
+    if (!packagerOptions.noNonInteractive && !isBerry) {
       args.push('--non-interactive');
     }
     if (!packagerOptions.noFrozenLockfile) {
-      args.push('--frozen-lockfile');
+      if (isBerry) {
+        args.push('--immutable');
+      } else {
+        args.push('--frozen-lockfile');
+      }
     }
     if (packagerOptions.ignoreScripts) {
       args.push('--ignore-scripts');
@@ -144,8 +165,8 @@ class Yarn {
   }
 
   // "Yarn install" prunes automatically
-  static prune(cwd, packagerOptions) {
-    return Yarn.install(cwd, packagerOptions);
+  static prune(cwd, packagerOptions, version) {
+    return Yarn.install(cwd, packagerOptions, version);
   }
 
   static runScripts(cwd, scriptNames) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-lodash": "^7.4.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-promise": "^6.0.1",
+        "eslint-plugin-promise": "^6.1.0",
         "husky": "^4.3.8",
         "jest": "^27.5.1",
         "lint-staged": "^10.5.4",
@@ -5192,9 +5192,9 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.1.tgz",
-      "integrity": "sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.0.tgz",
+      "integrity": "sha512-NYCfDZF/KHt27p06nFAttgWuFyIDSUMnNaJBIY1FY9GpBFhdT2vMG64HlFguSgcJeyM5by6Yr5csSOuJm60eXQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -18450,9 +18450,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.1.tgz",
-      "integrity": "sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.0.tgz",
+      "integrity": "sha512-NYCfDZF/KHt27p06nFAttgWuFyIDSUMnNaJBIY1FY9GpBFhdT2vMG64HlFguSgcJeyM5by6Yr5csSOuJm60eXQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-promise": "^6.0.1",
+    "eslint-plugin-promise": "^6.1.0",
     "husky": "^4.3.8",
     "jest": "^27.5.1",
     "lint-staged": "^10.5.4",

--- a/tests/packExternalModules.test.js
+++ b/tests/packExternalModules.test.js
@@ -21,6 +21,7 @@ jest.mock('../lib/packagers/index', () => {
     copyPackageSectionNames: ['section1', 'section2'],
     mustCopyModules: true,
     rebaseLockfile: jest.fn(),
+    getPackagerVersion: jest.fn(),
     getProdDependencies: jest.fn(),
     install: jest.fn(),
     prune: jest.fn(),
@@ -203,6 +204,7 @@ describe('packExternalModules', () => {
       fsExtraMock.pathExists.mockImplementation((p, cb) => cb(null, false));
       fsExtraMock.copy.mockImplementation((from, to, cb) => cb());
       packagerFactoryMock.get('npm').getProdDependencies.mockReturnValue(BbPromise.resolve({}));
+      packagerFactoryMock.get('npm').getPackagerVersion.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').install.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').prune.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').runScripts.mockReturnValue(BbPromise.resolve());
@@ -219,6 +221,7 @@ describe('packExternalModules', () => {
             expect(fsExtraMock.copy).toHaveBeenCalledTimes(1),
             // npm ls and npm prune should have been called
             expect(packagerFactoryMock.get('npm').getProdDependencies).toHaveBeenCalledTimes(1),
+            expect(packagerFactoryMock.get('npm').getPackagerVersion).toHaveBeenCalledTimes(2),
             expect(packagerFactoryMock.get('npm').install).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').prune).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').runScripts).toHaveBeenCalledTimes(1)
@@ -256,6 +259,7 @@ describe('packExternalModules', () => {
       fsExtraMock.pathExists.mockImplementation((p, cb) => cb(null, false));
       fsExtraMock.copy.mockImplementation((from, to, cb) => cb());
       packagerFactoryMock.get('npm').getProdDependencies.mockReturnValue(BbPromise.resolve({}));
+      packagerFactoryMock.get('npm').getPackagerVersion.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').install.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').prune.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').runScripts.mockReturnValue(BbPromise.resolve());
@@ -272,6 +276,7 @@ describe('packExternalModules', () => {
             expect(fsExtraMock.copy).toHaveBeenCalledTimes(1),
             // npm ls and npm prune should have been called
             expect(packagerFactoryMock.get('npm').getProdDependencies).toHaveBeenCalledTimes(1),
+            expect(packagerFactoryMock.get('npm').getPackagerVersion).toHaveBeenCalledTimes(2),
             expect(packagerFactoryMock.get('npm').install).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').prune).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').runScripts).toHaveBeenCalledTimes(1)
@@ -341,6 +346,7 @@ describe('packExternalModules', () => {
       fsExtraMock.copy.mockImplementation((from, to, cb) => cb());
       packagerFactoryMock.get('npm').getProdDependencies.mockReturnValue(BbPromise.resolve({}));
       packagerFactoryMock.get('npm').rebaseLockfile.mockImplementation((pathToPackageRoot, lockfile) => lockfile);
+      packagerFactoryMock.get('npm').getPackagerVersion.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').install.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').prune.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').runScripts.mockReturnValue(BbPromise.resolve());
@@ -371,6 +377,7 @@ describe('packExternalModules', () => {
             ),
             // npm ls and npm prune should have been called
             expect(packagerFactoryMock.get('npm').getProdDependencies).toHaveBeenCalledTimes(1),
+            expect(packagerFactoryMock.get('npm').getPackagerVersion).toHaveBeenCalledTimes(2),
             expect(packagerFactoryMock.get('npm').install).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').prune).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').runScripts).toHaveBeenCalledTimes(1)
@@ -412,6 +419,7 @@ describe('packExternalModules', () => {
       fsExtraMock.pathExists.mockImplementation((p, cb) => cb(null, false));
       fsExtraMock.copy.mockImplementation((from, to, cb) => cb());
       packagerFactoryMock.get('npm').getProdDependencies.mockReturnValue(BbPromise.resolve({}));
+      packagerFactoryMock.get('npm').getPackagerVersion.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').install.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').prune.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock.get('npm').runScripts.mockReturnValue(BbPromise.resolve());
@@ -428,6 +436,7 @@ describe('packExternalModules', () => {
             expect(fsExtraMock.copy).toHaveBeenCalledTimes(0),
             // npm ls and npm prune should have been called
             expect(packagerFactoryMock.get('npm').getProdDependencies).toHaveBeenCalledTimes(1),
+            expect(packagerFactoryMock.get('npm').getPackagerVersion).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').install).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').prune).toHaveBeenCalledTimes(0),
             expect(packagerFactoryMock.get('npm').runScripts).toHaveBeenCalledTimes(0)
@@ -440,6 +449,7 @@ describe('packExternalModules', () => {
       fsExtraMock.pathExists.mockImplementation((p, cb) => cb(null, false));
       fsExtraMock.copy.mockImplementation((from, to, cb) => cb());
       packagerFactoryMock.get('npm').getProdDependencies.mockReturnValue(BbPromise.resolve({}));
+      packagerFactoryMock.get('npm').getPackagerVersion.mockReturnValue(BbPromise.resolve());
       packagerFactoryMock
         .get('npm')
         .install.mockImplementation(() => BbPromise.reject(new Error('npm install failed')));
@@ -452,6 +462,7 @@ describe('packExternalModules', () => {
           BbPromise.all([
             // npm ls and npm install should have been called
             expect(packagerFactoryMock.get('npm').getProdDependencies).toHaveBeenCalledTimes(1),
+            expect(packagerFactoryMock.get('npm').getPackagerVersion).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').install).toHaveBeenCalledTimes(1),
             expect(packagerFactoryMock.get('npm').prune).toHaveBeenCalledTimes(0),
             expect(packagerFactoryMock.get('npm').runScripts).toHaveBeenCalledTimes(0)

--- a/tests/packagers/npm.test.js
+++ b/tests/packagers/npm.test.js
@@ -38,6 +38,36 @@ describe('npm', () => {
     expect(npmModule.mustCopyModules).toBe(true);
   });
 
+  describe('getPackagerVersion', () => {
+    it('should use npm version 6.14.17', () => {
+      const npmVersion = '6.14.17';
+      Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: npmVersion, stderr: '' }));
+      return expect(npmModule.getPackagerVersion('myPath', 1))
+        .resolves.toEqual(npmVersion)
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenNthCalledWith(1, expect.stringMatching(/^npm/), ['-v'], {
+            cwd: 'myPath'
+          });
+          return null;
+        });
+    });
+
+    it('should use npm version 8.19.2', () => {
+      const npmVersion = '8.19.2';
+      Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: npmVersion, stderr: '' }));
+      return expect(npmModule.getPackagerVersion('myPath', 1))
+        .resolves.toEqual(npmVersion)
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenNthCalledWith(1, expect.stringMatching(/^npm/), ['-v'], {
+            cwd: 'myPath'
+          });
+          return null;
+        });
+    });
+  });
+
   describe('install', () => {
     it('should use npm install', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));

--- a/tests/packagers/yarn.test.js
+++ b/tests/packagers/yarn.test.js
@@ -28,6 +28,48 @@ describe('yarn', () => {
     expect(yarnModule.mustCopyModules).toBe(false);
   });
 
+  describe('isBerryVersion', () => {
+    it('Yarn version 1.22.19', () => {
+      const yarnVersion = '1.22.19';
+      expect(yarnModule.isBerryVersion(yarnVersion)).toBe(false);
+    });
+
+    it('Yarn version 3.2.3', () => {
+      const yarnVersion = '3.2.3';
+      expect(yarnModule.isBerryVersion(yarnVersion)).toBe(true);
+    });
+  });
+
+  describe('getPackagerVersion', () => {
+    it('should use yarn version 1.22.19', () => {
+      const yarnVersion = '1.22.19';
+      Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: yarnVersion, stderr: '' }));
+      return expect(yarnModule.getPackagerVersion('myPath', 1))
+        .resolves.toEqual(yarnVersion)
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenNthCalledWith(1, expect.stringMatching(/^yarn/), ['-v'], {
+            cwd: 'myPath'
+          });
+          return null;
+        });
+    });
+
+    it('should use yarn version 3.2.3', () => {
+      const yarnVersion = '3.2.3';
+      Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: yarnVersion, stderr: '' }));
+      return expect(yarnModule.getPackagerVersion('myPath', 1))
+        .resolves.toEqual(yarnVersion)
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenNthCalledWith(1, expect.stringMatching(/^yarn/), ['-v'], {
+            cwd: 'myPath'
+          });
+          return null;
+        });
+    });
+  });
+
   describe('getProdDependencies', () => {
     it('should use yarn list', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: '{}', stderr: '' }));
@@ -198,7 +240,7 @@ describe('yarn', () => {
   describe('install', () => {
     it('should use yarn install', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
-      return expect(yarnModule.install('myPath', {}))
+      return expect(yarnModule.install('myPath', {}, '1.22.19'))
         .resolves.toBeUndefined()
         .then(() => {
           expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
@@ -215,7 +257,7 @@ describe('yarn', () => {
 
     it('should use noNonInteractive option', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
-      return expect(yarnModule.install('myPath', { noNonInteractive: true }))
+      return expect(yarnModule.install('myPath', { noNonInteractive: true }, '1.22.19'))
         .resolves.toBeUndefined()
         .then(() => {
           expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
@@ -232,7 +274,7 @@ describe('yarn', () => {
 
     it('should use ignoreScripts option', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
-      return expect(yarnModule.install('myPath', { ignoreScripts: true }))
+      return expect(yarnModule.install('myPath', { ignoreScripts: true }, '1.22.19'))
         .resolves.toBeUndefined()
         .then(() => {
           expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
@@ -249,7 +291,7 @@ describe('yarn', () => {
 
     it('should use noFrozenLockfile option', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
-      return expect(yarnModule.install('myPath', { noFrozenLockfile: true }))
+      return expect(yarnModule.install('myPath', { noFrozenLockfile: true }, '1.22.19'))
         .resolves.toBeUndefined()
         .then(() => {
           expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
@@ -266,7 +308,7 @@ describe('yarn', () => {
 
     it('should use networkConcurrency option', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'installed successfully', stderr: '' }));
-      return expect(yarnModule.install('myPath', { networkConcurrency: 1 }))
+      return expect(yarnModule.install('myPath', { networkConcurrency: 1 }, '1.22.19'))
         .resolves.toBeUndefined()
         .then(() => {
           expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
@@ -291,7 +333,7 @@ describe('yarn', () => {
   describe('prune', () => {
     it('should call install', () => {
       Utils.spawnProcess.mockReturnValue(BbPromise.resolve({ stdout: 'success', stderr: '' }));
-      return expect(yarnModule.prune('myPath', {}))
+      return expect(yarnModule.prune('myPath', {}, '1.22.19'))
         .resolves.toBeUndefined()
         .then(() => {
           expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes [#642](https://github.com/serverless-heaven/serverless-webpack/issues/642)

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

This is an upgrade to a previous [PR of mine](https://github.com/serverless-heaven/serverless-webpack/pull/1246).

The package can now detect the `Yarn` version to dynamically use the flags `--frozen-lockfile` or `--immutable` depending if running v1.x (classic) or v.2x, v3.x (modern).

If will also dynamically avoid injecting the flag `--non-interactive` even if you don't disable it on the `serverless.yml` file.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

`npm run test`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
