### PR TITLE
adding missing optional peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@babel/core": "^7.20.2",
         "@babel/eslint-parser": "^7.19.1",
         "@serverless/test": "^11.1.0",
+        "@types/node": "*",
         "coveralls": "^3.1.1",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
@@ -45,8 +46,18 @@
         "ts-node": ">= 8.3.0"
       },
       "peerDependencies": {
+        "@types/node": "*",
         "serverless": "1 || 2 || 3",
+        "typescript": ">=2.0",
         "webpack": ">= 3.0.0 < 6"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/core": "^7.20.2",
     "@babel/eslint-parser": "^7.19.1",
     "@serverless/test": "^11.1.0",
+    "@types/node": "*",
     "coveralls": "^3.1.1",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
@@ -63,8 +64,18 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "serverless": "1 || 2 || 3",
+    "typescript": ">=2.0",
     "webpack": ">= 3.0.0 < 6"
+  },
+  "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
   },
   "optionalDependencies": {
     "ts-node": ">= 8.3.0"


### PR DESCRIPTION
## What did you implement:

Updated optional peer dependencies to fix warnings

Closes #XXXXX - didn't make a ticket, pretty straight forward.

This screenshot sums up the issue pretty nicely. `yarn link` is using my changes, `yarn unlink` is using the version from npm:
<img width="945" alt="Screen Shot 2022-11-21 at 3 02 24 PM" src="https://user-images.githubusercontent.com/75625191/203158102-5ee74aca-25ab-4db1-bafb-4186b3213e3c.png">

## How did you implement it:

## How can we verify it:

If you have a project that's using serverless-webpack typescript, and ts-node, you'll see this warning appear when you install it. If you use my branch instead, the warning goes away.

## Todos:

- [N/A?] Write tests
- [N/A?] Write documentation
- [N/A] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** It shouldn't be. Added two `*` optional peer dependencies and optional peer `@typescript@>=2.0`, which was already a requirement of ts-node. I guess if they have typescript 1.X but don't have ts-node it would be breaking? Not sure how you want to classify that. Alternatively, changing it to `*` would mean it's definitely non-breaking.
