### PR TITLE
Allow generating ESM output from npm

### DIFF
--- a/lib/packagers/npm.js
+++ b/lib/packagers/npm.js
@@ -17,7 +17,7 @@ class NPM {
   }
 
   static get copyPackageSectionNames() {
-    return [];
+    return ['type'];
   }
 
   // eslint-disable-next-line lodash/prefer-constant

--- a/tests/packagers/npm.test.js
+++ b/tests/packagers/npm.test.js
@@ -31,7 +31,7 @@ describe('npm', () => {
   });
 
   it('should return no packager sections', () => {
-    expect(npmModule.copyPackageSectionNames).toEqual([]);
+    expect(npmModule.copyPackageSectionNames).toEqual(['type']);
   });
 
   it('requires to copy modules', () => {


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #1493

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:
- #381 appears to be exactly what's needed
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
- my project works when I include this change locally
- generating `.js` file allows `serverless invoke local` to work, and including `type: module` allows the deployed Lambda to work:
<img width="835" alt="image" src="https://github.com/serverless-heaven/serverless-webpack/assets/2145098/76a93177-bfbf-4c18-8443-f04508e34437">

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests - `packExternalModules.test.js` already ensures `copyPackageSectionNames` works
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
- breaking if someone has an ESM package.json today, but wants to produce CJS output
- if this is concerning, an alternative is to push this to a user-defined configuration option: #1495
