### PR TITLE
Allow generating ESM output from npm (non-breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,14 +406,31 @@ you should use any version `<5.5 >=5.7.1` as the versions in-between have some n
 
 The NPM packager supports the following `packagerOptions`:
 
-| Option             | Type   | Default               | Description                                         |
-| ------------------ | ------ | --------------------- | --------------------------------------------------- |
-| ignoreScripts      | bool   | false                 | Do not execute package.json hook scripts on install |
-| noInstall          | bool   | false                 | Do not run `npm install` (assume install completed) |
-| lockFile           | string | ./package-lock.json   | Relative path to lock file to use                   |
+| Option                  | Type     | Default             | Description                                                         |
+|-------------------------|----------|---------------------|---------------------------------------------------------------------|
+| ignoreScripts           | bool     | false               | Do not execute package.json hook scripts on install                 |
+| noInstall               | bool     | false               | Do not run `npm install` (assume install completed)                 |
+| lockFile                | string   | ./package-lock.json | Relative path to lock file to use                                   |
+| copyPackageSectionNames | string[] | []                  | Entries in your `package.json` to copy to the output `package.json` (ie: ESM output) |
 
 When using NPM version `>= 7.0.0`, we will use the `package-lock.json` file instead of modules installed in `node_modules`. This improves the
 supports of NPM `>= 8.0.0` which installs `peer-dependencies` automatically. The plugin will be able to detect the correct version.
+
+###### ESM output
+
+If you need to generate ESM output, and you cannot safely produce a `.mjs` file
+(e.g. [because that breaks serverless-offline](https://github.com/serverless/serverless/issues/11308)),
+you can use `copyPackageSectionNames` to ensure the output `package.json` defaults to ESM.
+
+```yaml
+custom:
+  webpack:
+    packagerOptions:
+      copyPackageSectionNames:
+        - type
+        - exports
+        - main
+```
 
 ##### Yarn
 
@@ -421,13 +438,14 @@ Using yarn will switch the whole packaging pipeline to use yarn, so does it use 
 
 The yarn packager supports the following `packagerOptions`:
 
-| Option             | Type | Default | Description                                         |
-| ------------------ | ---- | ------- | --------------------------------------------------- |
-| ignoreScripts      | bool | false   | Do not execute package.json hook scripts on install |
-| noInstall          | bool | false   | Do not run `yarn install` (assume install completed)|
-| noNonInteractive   | bool | false   | Disable interactive mode when using Yarn 2 or above |
-| noFrozenLockfile   | bool | false   | Do not require an up-to-date yarn.lock              |
-| networkConcurrency | int  |         | Specify number of concurrent network requests       |
+| Option                  | Type     | Default         | Description                                                         |
+|-------------------------|----------|-----------------|---------------------------------------------------------------------|
+| ignoreScripts           | bool     | false           | Do not execute package.json hook scripts on install                 |
+| noInstall               | bool     | false           | Do not run `yarn install` (assume install completed)                |
+| noNonInteractive        | bool     | false           | Disable interactive mode when using Yarn 2 or above                 |
+| noFrozenLockfile        | bool     | false           | Do not require an up-to-date yarn.lock                              |
+| networkConcurrency      | int      |                 | Specify number of concurrent network requests                       |
+| copyPackageSectionNames | string[] | ['resolutions'] | Entries in your `package.json` to copy to the output `package.json` |
 
 ##### Common packager options
 

--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -266,7 +266,7 @@ module.exports = {
     // Determine and create packager
     return BbPromise.try(() => Packagers.get.call(this, this.configuration.packager)).then(packager => {
       // Fetch needed original package.json sections
-      const sectionNames = packager.copyPackageSectionNames;
+      const sectionNames = packager.copyPackageSectionNames(this.configuration.packagerOptions);
       const packageJson = this.serverless.utils.readFileSync(packageJsonPath);
       const packageSections = _.pick(packageJson, sectionNames);
       if (!_.isEmpty(packageSections)) {

--- a/lib/packagers/index.js
+++ b/lib/packagers/index.js
@@ -7,8 +7,8 @@
  * interface Packager {
  *
  * static get lockfileName(): string;
- * static get copyPackageSectionNames(): Array<string>;
  * static get mustCopyModules(): boolean;
+ * static copyPackageSectionNames(packagerOptions: Object): Array<string>;
  * static getPackagerVersion(cwd: string): BbPromise<Object>
  * static getProdDependencies(cwd: string, depth: number = 1): BbPromise<Object>;
  * static rebaseLockfile(pathToPackageRoot: string, lockfile: Object): void;

--- a/lib/packagers/npm.js
+++ b/lib/packagers/npm.js
@@ -16,13 +16,14 @@ class NPM {
     return 'package-lock.json';
   }
 
-  static get copyPackageSectionNames() {
-    return [];
-  }
-
   // eslint-disable-next-line lodash/prefer-constant
   static get mustCopyModules() {
     return true;
+  }
+
+  static copyPackageSectionNames(packagerOptions) {
+    const options = packagerOptions || {};
+    return options.copyPackageSectionNames || [];
   }
 
   static getPackagerVersion(cwd) {

--- a/lib/packagers/yarn.js
+++ b/lib/packagers/yarn.js
@@ -21,13 +21,14 @@ class Yarn {
     return 'yarn.lock';
   }
 
-  static get copyPackageSectionNames() {
-    return ['resolutions'];
-  }
-
   // eslint-disable-next-line lodash/prefer-constant
   static get mustCopyModules() {
     return false;
+  }
+
+  static copyPackageSectionNames(packagerOptions) {
+    const options = packagerOptions || {};
+    return options.copyPackageSectionNames || ['resolutions'];
   }
 
   static isBerryVersion(version) {

--- a/tests/packagers/npm.test.js
+++ b/tests/packagers/npm.test.js
@@ -30,8 +30,12 @@ describe('npm', () => {
     expect(npmModule.lockfileName).toEqual('package-lock.json');
   });
 
-  it('should return no packager sections', () => {
-    expect(npmModule.copyPackageSectionNames).toEqual([]);
+  it('should return no packager sections by default', () => {
+    expect(npmModule.copyPackageSectionNames()).toEqual([]);
+  });
+
+  it('should return packager sections from config', () => {
+    expect(npmModule.copyPackageSectionNames({ copyPackageSectionNames: ['type'] })).toEqual(['type']);
   });
 
   it('requires to copy modules', () => {

--- a/tests/packagers/yarn.test.js
+++ b/tests/packagers/yarn.test.js
@@ -21,7 +21,11 @@ describe('yarn', () => {
   });
 
   it('should return packager sections', () => {
-    expect(yarnModule.copyPackageSectionNames).toEqual(['resolutions']);
+    expect(yarnModule.copyPackageSectionNames()).toEqual(['resolutions']);
+  });
+
+  it('should return packager sections from config', () => {
+    expect(yarnModule.copyPackageSectionNames({ copyPackageSectionNames: ['type'] })).toEqual(['type']);
   });
 
   it('does not require to copy modules', () => {


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #1493

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:
- non-breaking alternative approach to #1494
- [see this thread](https://github.com/serverless-heaven/serverless-webpack/pull/1494#discussion_r1232658185) to understand why that was a breaking change
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
- my project works when I include this change locally
- generating `.js` file allows `serverless invoke local` to work, and including `type: module` allows the deployed Lambda to work:
<img width="835" alt="image" src="https://github.com/serverless-heaven/serverless-webpack/assets/2145098/76a93177-bfbf-4c18-8443-f04508e34437">

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO