### PR TITLE
Fix `spawn EINVAL` on Windows when using Node > 20.12.2

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,7 +70,12 @@ class SpawnError extends Error {
  */
 function spawnProcess(command, args, options) {
   return new BbPromise((resolve, reject) => {
-    const child = childProcess.spawn(command, args, options);
+    const child = childProcess.spawn(command, args, {
+      ...options,
+      // nodejs 20 on windows doesn't allow `.cmd` command to run without `shell: true`
+      // https://github.com/serverless-heaven/serverless-webpack/issues/1791
+      shell: /^win/.test(process.platform)
+    });
     let stdout = '';
     let stderr = '';
     // Configure stream encodings


### PR DESCRIPTION
Fix https://github.com/serverless-heaven/serverless-webpack/issues/1791