### PR TITLE
fix: make `ts-node` dependency truly optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,15 +44,11 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "@types/node": "*",
         "serverless": "1 || 2 || 3",
         "ts-node": ">= 8.3.0",
         "webpack": ">= 3.0.0 < 6"
       },
       "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
         "ts-node": {
           "optional": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,17 +43,18 @@
       "engines": {
         "node": ">= 16"
       },
-      "optionalDependencies": {
-        "ts-node": ">= 8.3.0"
-      },
       "peerDependencies": {
         "@types/node": "*",
         "serverless": "1 || 2 || 3",
+        "ts-node": ">= 8.3.0",
         "typescript": ">=2.0",
         "webpack": ">= 3.0.0 < 6"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
           "optional": true
         },
         "typescript": {
@@ -1245,6 +1246,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1257,6 +1259,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3690,25 +3693,29 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4114,6 +4121,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4361,7 +4369,8 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5845,7 +5854,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -11927,7 +11937,8 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -15026,6 +15037,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15069,6 +15081,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -15448,7 +15461,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -15966,6 +15980,7 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "@types/node": "*",
         "serverless": "1 || 2 || 3",
         "ts-node": ">= 8.3.0",
-        "typescript": ">=2.0",
         "webpack": ">= 3.0.0 < 6"
       },
       "peerDependenciesMeta": {
@@ -55,9 +54,6 @@
           "optional": true
         },
         "ts-node": {
-          "optional": true
-        },
-        "typescript": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -66,15 +66,11 @@
     "webpack": "^5.92.0"
   },
   "peerDependencies": {
-    "@types/node": "*",
     "serverless": "1 || 2 || 3",
     "ts-node": ">= 8.3.0",
     "webpack": ">= 3.0.0 < 6"
   },
   "peerDependenciesMeta": {
-    "@types/node": {
-      "optional": true
-    },
     "ts-node": {
       "optional": true
     }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "peerDependencies": {
     "@types/node": "*",
     "serverless": "1 || 2 || 3",
+    "ts-node": ">= 8.3.0",
     "typescript": ">=2.0",
     "webpack": ">= 3.0.0 < 6"
   },
@@ -77,10 +78,10 @@
     },
     "typescript": {
       "optional": true
+    },
+    "ts-node": {
+      "optional": true
     }
-  },
-  "optionalDependencies": {
-    "ts-node": ">= 8.3.0"
   },
   "engines": {
     "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -69,14 +69,10 @@
     "@types/node": "*",
     "serverless": "1 || 2 || 3",
     "ts-node": ">= 8.3.0",
-    "typescript": ">=2.0",
     "webpack": ">= 3.0.0 < 6"
   },
   "peerDependenciesMeta": {
     "@types/node": {
-      "optional": true
-    },
-    "typescript": {
       "optional": true
     },
     "ts-node": {


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

`ts-node` is meant to be an opt-in dependency (as in, a dependency that is not installed by default, but will be used if installed) per #636, but it's been added as an optional dependency rather than an .. err ... "right kind of optional dependency" (aka peer dependency set as optional).

In the context of `package.json`, "optional dependencies" are ones that [the package manager _should try to install_](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#optionaldependencies) but skip if they error - they're intended for dependencies that are os-specific like `fsevents` or the underlying binaries for `esbuild` - so right now, `ts-node` will _always_ be installed because it does not have any os constraints, and in turn it leads to [complaints](https://github.com/serverless-heaven/serverless-webpack/issues/633) about [missing peer dependencies](https://github.com/serverless-heaven/serverless-webpack/pull/1287) via `ts-node`:

> If a dependency can be used, but you would like npm to proceed if it cannot be found or fails to install, then you may put it in the optionalDependencies object. This is a map of package name to version or URL, just like the dependencies object. The difference is that build failures do not cause installation to fail.

In the context of `package.json`, the correct way to express "optional" in the way most people think is to include the dependency as a peer dependency [with `optional: true` in its meta settings](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependenciesmeta).

> specifically, it allows peer dependencies to be marked as optional. Npm will not automatically install optional peer dependencies. This allows you to integrate and interact with a variety of host packages without requiring all of them to be installed.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I added `ts-node` as an optional peer dependency, and removed `typescript` and `@types/node` as peer dependencies since they're not used directly by `serverless-webpack`

## How can we verify it:

Install `serverless-webpack`, do an `npm ls` and see that `ts-node` isn't installed nor are there any dependency warnings - you can then install `typescript` and `ts-node`, and you'll still not have any dependency warnings.

Also see https://github.com/serverless/serverless-azure-functions/pull/517 for prior art

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] ~Write tests~
- [x] ~Write documentation~
- [x] ~Fix linting errors~
- [x] ~Make sure code coverage hasn't dropped~
- [x] ~Provide verification config / commands / resources~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** Debatable 😅 
