### PR TITLE
Prepare 5.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.14.0",
+  "version": "5.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.14.0",
+      "version": "5.14.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.14.0",
+  "version": "5.14.1",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
* fix: make `ts-node` dependency truly optional by @G-Rath in https://github.com/serverless-heaven/serverless-webpack/pull/1825
* When using `SLS_DEBUG` env var, more log will be dumped by @kennyhyun in https://github.com/serverless-heaven/serverless-webpack/pull/1803