### PR TITLE
refactor: ignore handlers with image.name property (fixes #1884)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,9 +123,9 @@ function getAllNodeFunctions() {
   return _.filter(functions, funcName => {
     const func = this.serverless.service.getFunction(funcName);
 
-    // if `uri` is provided or simple remote image path, it means the
+    // if `uri` or `name` is provided or simple remote image path, it means the
     // image isn't built by Serverless so we shouldn't take care of it
-    if ((func.image && func.image.uri) || (func.image && typeof func.image == 'string')) {
+    if ((func.image && (func.image.uri || func.image.name)) || (func.image && typeof func.image == 'string')) {
       return false;
     }
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -126,6 +126,65 @@ describe('Utils', () => {
     });
   });
 
+  describe('getAllNodeFunctions', () => {
+    it('should return all functions with node runtime', () => {
+      const mockServerless = {
+        service: {
+          getAllFunctions: jest.fn(() => ['foo', 'bar', 'baz']),
+          getFunction: jest.fn(name => {
+            if (name === 'foo') {
+              return { runtime: 'nodejs6.10' };
+            }
+            if (name === 'bar') {
+              return { runtime: 'nodejs8.10' };
+            }
+            if (name === 'baz') {
+              return { runtime: 'python3.6' };
+            }
+          })
+        }
+      };
+
+      expect(Utils.getAllNodeFunctions.call({ serverless: mockServerless })).toEqual(['foo', 'bar']);
+    });
+
+    it('should ignore handlers with image.uri property', () => {
+      const mockServerless = {
+        service: {
+          getAllFunctions: jest.fn(() => ['foo', 'bar']),
+          getFunction: jest.fn(name => {
+            if (name === 'foo') {
+              return { runtime: 'nodejs6.10' };
+            }
+            if (name === 'bar') {
+              return { runtime: 'nodejs8.10', image: { uri: 'fake-image-uri' } };
+            }
+          })
+        }
+      };
+
+      expect(Utils.getAllNodeFunctions.call({ serverless: mockServerless })).toEqual(['foo']);
+    });
+
+    it('should ignore handlers with image.name property', () => {
+      const mockServerless = {
+        service: {
+          getAllFunctions: jest.fn(() => ['foo', 'bar']),
+          getFunction: jest.fn(name => {
+            if (name === 'foo') {
+              return { runtime: 'nodejs6.10' };
+            }
+            if (name === 'bar') {
+              return { runtime: 'nodejs8.10', image: { name: 'fake-image-name' } };
+            }
+          })
+        }
+      };
+
+      expect(Utils.getAllNodeFunctions.call({ serverless: mockServerless })).toEqual(['foo']);
+    });
+  });
+
   describe('isProviderGoogle', () => {
     describe('when the provider is set to "google"', () => {
       const mockServerless = {


### PR DESCRIPTION
## What did you implement:

Closes #1884

Ignoring the handlers with the the `image.name` property the same way the ones with `image.uri` are ignored as they are lambda containers.

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Create a serverless template with both a lambda handler and a lambda container. The lambda container should have the `image.name` property poiting to an `ecr` image defined in the same template. The following example can be used:

```
service: converter

frameworkVersion: '3'

plugins:
  - serverless-webpack

custom:
  webpack:
    packager: yarn

package:
  individually: true

provider:
  name: aws
  ecr:
    images:
      image-test:
        path: ./

functions:
  functionHandler:
    handler: src/functions/funcionHandler.handler
    name: functionHandler-${sls:stage}
  
  functionContainer:
    name: functionContainer-${sls:stage}
    image:
      name:  image-test
      command:
        - 'functionContainer.handler'
```
Run serverless package

```
serverless package
```

The packager should not throw any error. It should package `functionHandler` and build the image `test-image` for the function `functionContainer` (you would need to make sure you have a valid `Dockerfile` in the root folder for image to build).

## output in master

<img width="825" alt="Screenshot 2024-08-10 at 13 48 30" src="https://github.com/user-attachments/assets/4bf169ea-f53f-4306-a1ad-5762f8daebf5">

## output in this branch

<img width="583" alt="Screenshot 2024-08-10 at 13 49 54" src="https://github.com/user-attachments/assets/71470dca-2ace-4f4b-8028-a3cabc4bd4be">


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
