### PR TITLE
Remove progress message once the compilation is done

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -187,6 +187,11 @@ module.exports = {
       .call(this, configs, logStats, concurrency, this.serverless.classes.Error)
       .then(stats => {
         this.compileStats = { stats };
+
+        if (this.log) {
+          this.progress.get('webpack').remove();
+        }
+
         return BbPromise.resolve();
       });
   }


### PR DESCRIPTION
It looks like the behavior is unhandled from the log migration from Serverless v2 to v3. Before starting to build, a message is displayed using the progress object from Serverless v3. However that message never disappeared once the building is done.

Might be related to https://github.com/serverless-heaven/serverless-webpack/pull/1013
Fix #2172 