### PR TITLE
Prepare 5.15.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       timezone: Europe/Paris
     open-pull-requests-limit: 10
     versioning-strategy: increase
+    exclude-paths:
+      - "examples/**"
+      - "tests/**"
     groups:
       babel-dependencies:
         patterns:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Serverless Webpack
 
-[![Serverless][ico-serverless]][link-serverless]
 [![License][ico-license]][link-license]
 [![NPM][ico-npm]][link-npm]
 [![Build Status][ico-build]][link-build]
@@ -924,7 +923,6 @@ me to take it over and continue working on the project. That helped to revive it
 
 See [the releases section](https://github.com/serverless-heaven/serverless-webpack/releases)
 
-[ico-serverless]: http://public.serverless.com/badges/v3.svg
 [ico-license]: https://img.shields.io/github/license/serverless-heaven/serverless-webpack.svg
 [ico-npm]: https://img.shields.io/npm/v/serverless-webpack.svg
 [ico-build]: https://github.com/serverless-heaven/serverless-webpack/actions/workflows/tests.yml/badge.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.15.2",
+  "version": "5.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.15.2",
+      "version": "5.15.3",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",
@@ -44,7 +44,7 @@
         "webpack": "^5.101.3"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "serverless": "1 || 2 || 3 || 4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.15.2",
+  "version": "5.15.3",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",
@@ -78,6 +78,6 @@
     }
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }


### PR DESCRIPTION
- Drop Node < 18
- remove dead serverless icon from readme
- add `exclude-paths` to Dependabot to avoid `examples` folder to trigger security issues
