### PR TITLE
Add osls to the tests suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,3 +168,65 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           SERVERLESS_ACCESS_KEY: ${{secrets.SERVERLESS_ACCESS_KEY}}
+
+  osls-v3:
+    runs-on: ${{ matrix.os }}
+    name: Node.js ${{ matrix.node }} on ${{ matrix.os }} with osls v3
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        node:
+          - 20
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: 'Install Node.js'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '${{ matrix.node }}'
+
+      - name: 'Install dependencies'
+        run: npm ci
+
+      - name: "Install osls v3"
+        run: npm install --no-save --package-lock=false serverless@npm:osls@3
+
+      - name: 'Run tests'
+        run: 'npm run test'
+
+  osls-v4:
+    runs-on: ${{ matrix.os }}
+    name: Node.js ${{ matrix.node }} on ${{ matrix.os }} with osls v4
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        node:
+          - 20
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: 'Install Node.js'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '${{ matrix.node }}'
+
+      - name: 'Install dependencies'
+        run: npm ci
+
+      - name: "Install osls v4"
+        run: npm install --no-save --package-lock=false serverless@npm:osls@4
+
+      - name: 'Run tests'
+        run: 'npm run test'

--- a/examples/include-external-npm-packages-lock-file/_setup.js
+++ b/examples/include-external-npm-packages-lock-file/_setup.js
@@ -4,6 +4,28 @@
 
 const path = require('path');
 
+function replacePluginLockReference(lockPath, pluginPackagePath, utils) {
+  return utils.replaceInJson(lockPath, lock => {
+    const pluginPackage = lock.packages['../..'];
+    const installedPackage = lock.packages['node_modules/serverless-webpack'] || {};
+
+    if (!pluginPackage || !lock.packages['']?.devDependencies) {
+      throw new Error('Unexpected package-lock structure for serverless-webpack local file dependency.');
+    }
+
+    lock.packages[''].devDependencies['serverless-webpack'] = `file:${pluginPackagePath}`;
+    delete lock.packages['../..'];
+    lock.packages['node_modules/serverless-webpack'] = {
+      ...pluginPackage,
+      ...installedPackage,
+      resolved: `file:${pluginPackagePath}`
+    };
+    delete lock.packages['node_modules/serverless-webpack'].link;
+
+    return lock;
+  });
+}
+
 module.exports = async (originalFixturePath, fixturePath, utils) => {
   const pluginPath = path.resolve(originalFixturePath, '..', '..');
 
@@ -15,8 +37,8 @@ module.exports = async (originalFixturePath, fixturePath, utils) => {
   await Promise.all([
     utils.replaceInFile(SLS_CONFIG_PATH, '- serverless-webpack', `- ${pluginPath}`),
     utils.replaceInFile(WEBPACK_CONFIG_PATH, "'serverless-webpack'", `'${pluginPath}'`),
-    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${pluginPath}`),
-    utils.replaceInFile(LOCK_PATH, '../..', `${pluginPath}`)
+    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${utils.pluginPackagePath}`),
+    replacePluginLockReference(LOCK_PATH, utils.pluginPackagePath, utils)
   ]);
 
   const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';

--- a/examples/include-external-npm-packages-with-yarn-workspaces/_setup.js
+++ b/examples/include-external-npm-packages-with-yarn-workspaces/_setup.js
@@ -15,8 +15,8 @@ module.exports = async (originalFixturePath, fixturePath, utils) => {
   await Promise.all([
     utils.replaceInFile(SLS_CONFIG_PATH, '- serverless-webpack', `- ${pluginPath}`),
     utils.replaceInFile(WEBPACK_CONFIG_PATH, "'serverless-webpack'", `'${pluginPath}'`),
-    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${pluginPath}`),
-    utils.replaceInFile(LOCK_PATH, '../..', `${pluginPath}`)
+    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${utils.pluginPackagePath}`),
+    utils.replaceInFile(LOCK_PATH, 'file:.', `file:${utils.pluginPackagePath}`)
   ]);
 
   const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';

--- a/examples/include-external-npm-packages/_setup.js
+++ b/examples/include-external-npm-packages/_setup.js
@@ -15,8 +15,8 @@ module.exports = async (originalFixturePath, fixturePath, utils) => {
   await Promise.all([
     utils.replaceInFile(SLS_CONFIG_PATH, '- serverless-webpack', `- ${pluginPath}`),
     utils.replaceInFile(WEBPACK_CONFIG_PATH, "'serverless-webpack'", `'${pluginPath}'`),
-    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${pluginPath}`),
-    utils.replaceInFile(LOCK_PATH, 'file:../..', `file:${pluginPath}`)
+    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${utils.pluginPackagePath}`),
+    utils.replaceInFile(LOCK_PATH, 'file:../..', `file:${utils.pluginPackagePath}`)
   ]);
 
   const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';

--- a/examples/serverless-v4/_setup.js
+++ b/examples/serverless-v4/_setup.js
@@ -15,8 +15,8 @@ module.exports = async (originalFixturePath, fixturePath, utils) => {
   await Promise.all([
     utils.replaceInFile(SLS_CONFIG_PATH, '- serverless-webpack', `- ${pluginPath}`),
     utils.replaceInFile(WEBPACK_CONFIG_PATH, "'serverless-webpack'", `'${pluginPath}'`),
-    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${pluginPath}`),
-    utils.replaceInFile(LOCK_PATH, 'file:../..', `file:${pluginPath}`)
+    utils.replaceInFile(PACKAGE_JSON_PATH, 'file:../..', `file:${utils.pluginPackagePath}`),
+    utils.replaceInFile(LOCK_PATH, 'file:../..', `file:${utils.pluginPackagePath}`)
   ]);
 
   const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const childProcess = require('node:child_process');
+const MAX_SPAWN_ERROR_OUTPUT_LENGTH = 8000;
 
 function guid() {
   function s4() {
@@ -44,14 +45,37 @@ function searchAndProcessCache(moduleName, processor) {
 }
 
 class SpawnError extends Error {
-  constructor(message, stdout, stderr) {
-    super(message);
+  constructor(message, stdout, stderr, options = {}) {
+    const truncateOutput = output => {
+      if (output.length <= MAX_SPAWN_ERROR_OUTPUT_LENGTH) {
+        return output;
+      }
+
+      const remainingCharacters = output.length - MAX_SPAWN_ERROR_OUTPUT_LENGTH;
+      const suffix = remainingCharacters === 1 ? 'character' : 'characters';
+
+      return `${output.slice(0, MAX_SPAWN_ERROR_OUTPUT_LENGTH)}\n... output truncated (${remainingCharacters} more ${suffix})`;
+    };
+
+    const formattedMessage = [
+      message,
+      options.cwd && `cwd: ${options.cwd}`,
+      stdout && `stdout:\n${truncateOutput(stdout)}`,
+      stderr && `stderr:\n${truncateOutput(stderr)}`
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    super(formattedMessage);
     this.stdout = stdout;
     this.stderr = stderr;
+    this.command = options.command;
+    this.args = options.args;
+    this.cwd = options.cwd;
   }
 
   toString() {
-    return `${this.message}\n${this.stderr}`;
+    return this.message;
   }
 }
 
@@ -85,15 +109,25 @@ function spawnProcess(command, args = [], options) {
       stderr += data;
     });
     child.on('error', err => {
-      if (process.env.NODE_ENV === 'test') {
-        console.error(err);
+      const commandLine = [command, ...normalizedArgs].join(' ');
+      let message = `${commandLine} failed to start.`;
+
+      if (err.code === 'ENOENT') {
+        message += ` Command "${command}" was not found. Make sure it is installed and available in PATH.`;
       }
 
-      reject(err);
+      message += ` Original error: ${err.message}`;
+
+      reject(new SpawnError(message, stdout, stderr, { command, args: normalizedArgs, cwd: options?.cwd }));
     });
-    child.on('close', exitCode => {
+    child.on('close', (exitCode, signal) => {
       if (exitCode !== 0) {
-        reject(new SpawnError(`${command} ${normalizedArgs.join(' ')} failed with code ${exitCode}`, stdout, stderr));
+        const commandLine = [command, ...normalizedArgs].join(' ');
+        const message = signal
+          ? `${commandLine} failed after receiving signal ${signal}`
+          : `${commandLine} failed with code ${exitCode}`;
+
+        reject(new SpawnError(message, stdout, stderr, { command, args: normalizedArgs, cwd: options?.cwd }));
       } else {
         resolve({ stdout, stderr });
       }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -47,8 +47,9 @@ module.exports = {
     };
 
     const getEntryExtension = fileName => {
+      const servicePath = this.serverless.config.servicePath ?? undefined;
       const files = glob.sync(`${fileName}.*`, {
-        cwd: this.serverless.config.servicePath,
+        cwd: servicePath,
         nodir: true,
         ignore: this.configuration.excludeFiles ? this.configuration.excludeFiles : undefined
       });
@@ -56,7 +57,7 @@ module.exports = {
       if (_.isEmpty(files)) {
         // If we cannot find any handler we should terminate with an error
         throw new this.serverless.classes.Error(
-          `No matching handler found for '${fileName}' in '${this.serverless.config.servicePath}'. Check your service definition.`
+          `No matching handler found for '${fileName}' in '${servicePath ?? process.cwd()}'. Check your service definition.`
         );
       }
 

--- a/tests/e2e/e2eUtils.js
+++ b/tests/e2e/e2eUtils.js
@@ -6,6 +6,8 @@ const originalRunServerless = require('@serverless/test/run-serverless');
 const { spawnProcess } = require('../../lib/utils');
 
 const FIXTURES_DIR = path.resolve(__dirname, '..', '..', 'examples');
+const PROJECT_DIR = path.resolve(__dirname, '..', '..');
+let pluginPackagePathPromise;
 
 async function replaceInFile(path, regex, replacement) {
   const content = await fse.readFile(path, 'utf8');
@@ -13,16 +15,51 @@ async function replaceInFile(path, regex, replacement) {
   return fse.writeFile(path, updatedContent);
 }
 
+async function replaceInJson(path, updater) {
+  const content = await fse.readJson(path);
+  const updatedContent = updater(content) || content;
+  return fse.writeJson(path, updatedContent, { spaces: 2 });
+}
+
 async function setupFixture(name) {
   const fixturePath = path.join(FIXTURES_DIR, name);
   const setupFixturePath = await provisionTmpDir();
+  const pluginPackagePath = await getPluginPackagePath();
   await fse.copy(fixturePath, setupFixturePath);
 
   const setupScriptPath = path.resolve(setupFixturePath, '_setup.js');
-  await require(setupScriptPath)(fixturePath, setupFixturePath, { replaceInFile, spawnProcess });
+  await require(setupScriptPath)(fixturePath, setupFixturePath, {
+    pluginPackagePath,
+    replaceInJson,
+    replaceInFile,
+    spawnProcess
+  });
   await fse.unlink(setupScriptPath);
 
   return setupFixturePath;
+}
+
+async function getPluginPackagePath() {
+  if (!pluginPackagePathPromise) {
+    pluginPackagePathPromise = (async () => {
+      const packageDir = await provisionTmpDir();
+      const npmCommand = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+      const { stdout } = await spawnProcess(
+        npmCommand,
+        ['pack', '--pack-destination', packageDir, '--cache', path.join(packageDir, '.npm-cache')],
+        { cwd: PROJECT_DIR }
+      );
+      const packageFile = stdout.trim().split(/\r?\n/).pop();
+      const packagePath = path.isAbsolute(packageFile) ? packageFile : path.join(packageDir, packageFile);
+
+      return packagePath.replace(/\\/g, '/');
+    })();
+    pluginPackagePathPromise.catch(() => {
+      pluginPackagePathPromise = undefined;
+    });
+  }
+
+  return pluginPackagePathPromise;
 }
 
 async function runServerless(options) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -24,15 +24,27 @@ describe('Utils', () => {
   describe('SpawnError', () => {
     it('should store stdout and stderr', () => {
       const err = new Utils.SpawnError('message', 'stdout', 'stderr');
-      expect(err).toHaveProperty('message', 'message');
+      expect(err).toHaveProperty('message', 'message\nstdout:\nstdout\nstderr:\nstderr');
       expect(err).toHaveProperty('stdout', 'stdout');
       expect(err).toHaveProperty('stderr', 'stderr');
     });
 
-    it('should print message and stderr', () => {
-      const err = new Utils.SpawnError('message', 'stdout', 'stderr');
+    it('should include cwd, stdout and stderr in toString()', () => {
+      const err = new Utils.SpawnError('message', 'stdout', 'stderr', { cwd: 'cwd' });
 
-      expect(err.toString()).toEqual('message\nstderr');
+      expect(err.toString()).toEqual('message\ncwd: cwd\nstdout:\nstdout\nstderr:\nstderr');
+    });
+
+    it('should truncate stdout and stderr in message only', () => {
+      const stdout = 'o'.repeat(8001);
+      const stderr = 'e'.repeat(8001);
+      const err = new Utils.SpawnError('message', stdout, stderr);
+
+      expect(err.message).toContain('stdout:\n');
+      expect(err.message).toContain('stderr:\n');
+      expect(err.message).toContain('... output truncated (1 more character)');
+      expect(err.stdout).toEqual(stdout);
+      expect(err.stderr).toEqual(stderr);
     });
   });
 
@@ -92,10 +104,14 @@ describe('Utils', () => {
       childMock.on.mockReset();
       childMock.on.mockImplementation((name, cb) => {
         if (name === 'error') {
-          cb(new Error('spawn ENOENT'));
+          const err = new Error('spawn ENOENT');
+          err.code = 'ENOENT';
+          cb(err);
         }
       });
-      return expect(Utils.spawnProcess('cmd', [])).rejects.toThrow('spawn ENOENT');
+      return expect(Utils.spawnProcess('cmd', [])).rejects.toThrow(
+        'cmd failed to start. Command "cmd" was not found. Make sure it is installed and available in PATH. Original error: spawn ENOENT'
+      );
     });
 
     it('should reject on positive exit code', () => {
@@ -106,6 +122,16 @@ describe('Utils', () => {
         }
       });
       return expect(Utils.spawnProcess('cmd', [])).rejects.toThrow(Utils.SpawnError);
+    });
+
+    it('should reject with signal on process termination', () => {
+      childMock.on.mockReset();
+      childMock.on.mockImplementation((name, cb) => {
+        if (name === 'close') {
+          cb(null, 'SIGTERM');
+        }
+      });
+      return expect(Utils.spawnProcess('cmd', [])).rejects.toThrow('cmd failed after receiving signal SIGTERM');
     });
 
     it('should allow omitted args', () => {

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -1097,29 +1097,12 @@ describe('validate', () => {
 
             expect(lib.entries).toEqual(expectedLibEntries);
 
-            // handle different stub in case of serverless version
-            if (serverless.version.match(/^1/)) {
-              expect(globMock.sync).toHaveBeenCalledTimes(1);
-              expect(globMock.sync).toHaveBeenCalledWith('module1.*', {
-                ignore: '**/*.ts',
-                cwd: null,
-                nodir: true
-              });
-            } else if (serverless.version.match(/^3/)) {
-              expect(globMock.sync).toHaveBeenCalledTimes(1);
-              expect(globMock.sync).toHaveBeenCalledWith('module1.*', {
-                cwd: null,
-                nodir: true,
-                ignore: '**/*.ts'
-              });
-            } else {
-              expect(globMock.sync).toHaveBeenCalledTimes(1);
-              expect(globMock.sync).toHaveBeenCalledWith('module1.*', {
-                ignore: '**/*.ts',
-                cwd: undefined,
-                nodir: true
-              });
-            }
+            expect(globMock.sync).toHaveBeenCalledTimes(1);
+            expect(globMock.sync).toHaveBeenCalledWith('module1.*', {
+              ignore: '**/*.ts',
+              cwd: undefined,
+              nodir: true
+            });
 
             expect(serverless.cli.log).toHaveBeenCalledTimes(0);
             return null;
@@ -1142,7 +1125,7 @@ describe('validate', () => {
         globMock.sync.mockReturnValue([]);
         expect(() => {
           module.validate();
-        }).toThrow(/No matching handler found for/);
+        }).toThrow(`No matching handler found for 'module1' in '${process.cwd()}'. Check your service definition.`);
       });
 
       it('should throw an exception if `options.function` is defined but not found in entries from serverless.yml', () => {


### PR DESCRIPTION
Adding both v3 & v4

Also:
- improve packaging when using Yarn. Before, the `file:<repo>` was packing all the repo. Now we are generating a proper package using `npm pack`, it's faster (at least when using yarn)
- improve error reporting