### PR TITLE
Fix Biome config

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -19,7 +19,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "complexity": {
         "noStaticOnlyClass": "off"
       },


### PR DESCRIPTION
Just updated the schema and converted the `recommended` key as `preset`.

```
$ yarn format
yarn run v1.22.22
$ biome check --write --unsafe
biome.jsonc:2:14 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ℹ The configuration schema version does not match the CLI version 2.5.2

    1 │ {
  > 2 │   "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
      │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 │   "vcs": {
    4 │     "enabled": true,

  ℹ   Expected:                     2.5.2
      Found:                        2.4.12


  ℹ Run the command biome migrate to migrate the configuration file.


biome.jsonc:19:13 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ℹ The use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.

    17 │     "lineWidth": 120
    18 │   },
  > 19 │   "linter": {
       │             ^
  > 20 │     "enabled": true,
        ...
  > 34 │     }
  > 35 │   },
       │   ^
    36 │   "javascript": {
    37 │     "formatter": {

  ℹ Migrate the configuration with the proper command

  $ biome migrate


Checked 56 files in 96ms. No fixes applied.
Found 2 infos.
✨  Done in 0.45s
```