### PR TITLE
Remove token from npm publish step

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,5 +1,9 @@
 name: Publish new release on NPM
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   release:
     types:
@@ -28,5 +32,3 @@ jobs:
 
       - name: 'Publish package'
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.16.0",
+  "version": "5.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.16.0",
+      "version": "5.16.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.16.0",
+  "version": "5.16.1",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Previous publication failed: https://github.com/serverless-heaven/serverless-webpack/actions/runs/29021017975/job/86130393038

Otherwise trusted publishing doesn't work (hopefully)

Prepare 5.16.1