### PR TITLE
Use Node 24 to publish package

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -21,8 +21,9 @@ jobs:
       - name: 'Install Node.js'
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          node-version: '24'
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
 
       - name: 'Install dependencies'
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-webpack",
-  "version": "5.16.1",
+  "version": "5.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-webpack",
-      "version": "5.16.1",
+      "version": "5.16.2",
       "license": "MIT",
       "dependencies": {
         "archiver": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "5.16.1",
+  "version": "5.16.2",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Node 24 include NPM 11 which is minimum required version to work with Trusted Publisher (OIDC)

And prepare 5.16.2 -_-