### PR TITLE
feat: add installExtraArgs packager option

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ The NPM packager supports the following `packagerOptions`:
 | noInstall               | bool     | false               | Do not run `npm install` (assume install completed)                 |
 | lockFile                | string   | ./package-lock.json | Relative path to lock file to use                                   |
 | copyPackageSectionNames | string[] | []                  | Entries in your `package.json` to copy to the output `package.json` (ie: ESM output) |
+| installExtraArgs        | string[] | []                  | Additional arguments appended to the `npm install` command (ie: `['--os=linux', '--cpu=arm64']` to resolve optional native dependencies for a target platform other than the build host) |
 
 When using NPM version `>= 7.0.0`, we will use the `package-lock.json` file instead of modules installed in `node_modules`. This improves the
 supports of NPM `>= 8.0.0` which installs `peer-dependencies` automatically. The plugin will be able to detect the correct version.
@@ -447,6 +448,7 @@ The yarn packager supports the following `packagerOptions`:
 | noNonInteractive        | bool     | false           | Disable interactive mode when using Yarn 2 or above                 |
 | noFrozenLockfile        | bool     | false           | Do not require an up-to-date yarn.lock                              |
 | networkConcurrency      | int      |                 | Specify number of concurrent network requests                       |
+| installExtraArgs        | string[] | []              | Additional arguments appended to the `yarn install` command         |
 | copyPackageSectionNames | string[] | ['resolutions'] | Entries in your `package.json` to copy to the output `package.json` |
 
 ##### Common packager options

--- a/lib/packagers/npm.js
+++ b/lib/packagers/npm.js
@@ -145,6 +145,10 @@ class NPM {
       args.push('--ignore-scripts');
     }
 
+    if (!_.isEmpty(packagerOptions.installExtraArgs)) {
+      args.push(...packagerOptions.installExtraArgs);
+    }
+
     await Utils.spawnProcess(command, args, { cwd });
   }
 

--- a/lib/packagers/yarn.js
+++ b/lib/packagers/yarn.js
@@ -163,6 +163,10 @@ class Yarn {
       args.push(`--network-concurrency ${packagerOptions.networkConcurrency}`);
     }
 
+    if (!_.isEmpty(packagerOptions.installExtraArgs)) {
+      args.push(...packagerOptions.installExtraArgs);
+    }
+
     await Utils.spawnProcess(command, args, { cwd });
   }
 

--- a/tests/packagers/npm.test.js
+++ b/tests/packagers/npm.test.js
@@ -126,6 +126,23 @@ describe('npm', () => {
           return null;
         });
     });
+
+    it('should use installExtraArgs option', () => {
+      Utils.spawnProcess.mockReturnValue(Promise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(npmModule.install('myPath', { installExtraArgs: ['--os=linux', '--cpu=arm64'] }))
+        .resolves.toBeUndefined()
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenCalledWith(
+            expect.stringMatching(/^npm/),
+            ['install', '--os=linux', '--cpu=arm64'],
+            {
+              cwd: 'myPath'
+            }
+          );
+          return null;
+        });
+    });
   });
 
   describe('noInstall', () => {

--- a/tests/packagers/yarn.test.js
+++ b/tests/packagers/yarn.test.js
@@ -265,6 +265,23 @@ describe('yarn', () => {
         });
     });
 
+    it('should use installExtraArgs option', () => {
+      Utils.spawnProcess.mockReturnValue(Promise.resolve({ stdout: 'installed successfully', stderr: '' }));
+      return expect(yarnModule.install('myPath', { installExtraArgs: ['--production'] }, '1.22.19'))
+        .resolves.toBeUndefined()
+        .then(() => {
+          expect(Utils.spawnProcess).toHaveBeenCalledTimes(1);
+          expect(Utils.spawnProcess).toHaveBeenCalledWith(
+            expect.stringMatching(/^yarn/),
+            ['install', '--non-interactive', '--frozen-lockfile', '--production'],
+            {
+              cwd: 'myPath'
+            }
+          );
+          return null;
+        });
+    });
+
     it('should use noNonInteractive option', () => {
       Utils.spawnProcess.mockReturnValue(Promise.resolve({ stdout: 'installed successfully', stderr: '' }));
       return expect(yarnModule.install('myPath', { noNonInteractive: true }, '1.22.19'))


### PR DESCRIPTION
## What did you implement:

Closes #2521

Adds an `installExtraArgs` packager option that appends arbitrary arguments to the packager's install command, so cross-platform builds can be expressed in `serverless.yml`:

```yaml
custom:
  webpack:
    includeModules: true
    packagerOptions:
      installExtraArgs: ['--os=linux', '--cpu=arm64', '--libc=glibc']
```

The motivating case is native modules distributed as per-platform optional dependencies (napi-rs, esbuild, lightningcss, `@parcel/watcher`, …). npm resolves those against the machine running the install, so building for an architecture other than the build host silently packages the wrong binary — it works locally and fails at runtime in Lambda. npm's `--os` / `--cpu` / `--libc` fix it, but there was no way to pass them through. `serverless-esbuild` already exposes an option of the same name.

## How did you implement it:

Four lines in each packager, guarded so the default is unchanged:

```js
if (!_.isEmpty(packagerOptions.installExtraArgs)) {
  args.push(...packagerOptions.installExtraArgs);
}
```

Appended last so the arguments the plugin needs for correctness (`--frozen-lockfile`, `--ignore-scripts`, …) are still applied. `lodash` was already imported in both files. Added to yarn as well as npm for symmetry — it's equally useful for passing through flags the plugin doesn't model.

Not a breaking change: absent or empty, the argument list is byte-identical to before.

## How can we verify it:

Unit tests added for both packagers, asserting the exact spawn arguments:

```
npx jest tests/packagers -t installExtraArgs
```

Full suite is green — 18 suites, 284 passed, 2 pre-existing skips — and `npm run lint` is clean.

End to end, on a macOS arm64 host with a package that ships per-platform binaries:

```js
const NPM = require('serverless-webpack/lib/packagers/npm');
NPM.install(compositeDir, { installExtraArgs: ['--os=linux', '--cpu=arm64', '--libc=glibc'] });
```

installs the `linux-arm64-gnu` package instead of `darwin-arm64`. Without the option the host's package is installed, reproducing the bug.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO